### PR TITLE
Fix some typescript compile errors in joy-utils

### DIFF
--- a/packages/joy-utils/src/accounts.ts
+++ b/packages/joy-utils/src/accounts.ts
@@ -1,4 +1,4 @@
-import { hexToU8a, stringToU8a } from '@polkadot/util';
+import { stringToU8a } from '@polkadot/util';
 import { AccountId } from '@polkadot/types';
 
 export const Names = {
@@ -9,7 +9,7 @@ export const Names = {
   Eve:     'Eve'
 };
 
-export const Addresses = {
+export const Addresses:any = {
   Alice:   '5GoKvZWG5ZPYL1WUovuHW3zJBWBP5eT8CbqjdRY4Q6iMaDtZ',
   Bob:     '5Gw3s7q4QLkSWwknsiPtjujPv3XM4Trxi5d4PgKMMk3gfGTE',
   Charlie: '5FmE1Adpwp1bT1oY95w59RiSPVu9QwzBGjKsE2hxemD2AFs8',

--- a/packages/joy-utils/src/types.ts
+++ b/packages/joy-utils/src/types.ts
@@ -1,6 +1,6 @@
 import typeRegistry from '@polkadot/types/codec/typeRegistry';
 import { Enum, EnumType } from '@polkadot/types/codec';
-import { BlockNumber, AccountId, Balance, Hash, u32, Text } from '@polkadot/types';
+import { BlockNumber, AccountId, Balance, u32, Text } from '@polkadot/types';
 
 export type ProposalId = u32;
 


### PR DESCRIPTION
`yarn build` was spitting out too many compile errors, here are a few fixes only for `joy-utils`.
Even though joy-utils compiles without errors, the dependent apps still output:

`ui-app/src/AddressMiniJoy.tsx:16:35 - error TS2307: Cannot find module '@polkadot/joy-utils/'.`