### PR TITLE
rename Proposal to RuntimeUpgradeProposal

### DIFF
--- a/packages/joy-proposals/src/mocks.ts
+++ b/packages/joy-proposals/src/mocks.ts
@@ -1,5 +1,5 @@
 import { BlockNumber, Balance, u32, Text } from '@polkadot/types';
-import { Proposal, ProposalStatus, ProposalVote, VoteKind } from '@polkadot/joy-utils/types';
+import { RuntimeUpgradeProposal, ProposalStatus, ProposalVote, VoteKind } from '@polkadot/joy-utils/types';
 import { AccountIds } from '@polkadot/joy-utils/accounts';
 
 export const ProposalVotesMock: ProposalVote[] = [
@@ -17,7 +17,7 @@ export const ProposalVotesMock: ProposalVote[] = [
   }
 ];
 
-export const ProposalsMock: Proposal[] = [
+export const ProposalsMock: RuntimeUpgradeProposal[] = [
   {
     id: new u32(1),
     proposer: AccountIds.Bob,

--- a/packages/joy-utils/src/types.ts
+++ b/packages/joy-utils/src/types.ts
@@ -4,7 +4,7 @@ import { BlockNumber, AccountId, Balance, u32, Text } from '@polkadot/types';
 
 export type ProposalId = u32;
 
-export type Proposal = {
+export type RuntimeUpgradeProposal = {
   id: ProposalId,
   proposer: AccountId,
   stake: Balance,
@@ -90,7 +90,7 @@ export function registerJoystreamTypes () {
         'backing': 'Balance'
       },
       'ProposalId': 'u32',
-      'Proposal': {
+      'RuntimeUpgradeProposal': {
         'id': 'ProposalId',
         'proposer': 'AccountId',
         'stake': 'Balance',


### PR DESCRIPTION
Goes with https://github.com/Joystream/substrate-node-joystream/pull/23

Rename to avoid overriding Proposal type defined in @polkadot/types