### PR TITLE
Fix 99% of TypeScript errors

### DIFF
--- a/packages/apps/src/SideBar/index.tsx
+++ b/packages/apps/src/SideBar/index.tsx
@@ -86,6 +86,7 @@ class SideBar extends React.PureComponent<Props, State> {
     );
   }
 
+  // @ts-ignore is declared but its value is never read
   private renderLogo () {
     const { isCollapsed } = this.state;
     const logo = getLogo(isCollapsed);
@@ -135,6 +136,7 @@ class SideBar extends React.PureComponent<Props, State> {
     ));
   }
 
+  // @ts-ignore is declared but its value is never read
   private renderGithub () {
     return (
       <Menu.Item className='apps--SideBar-Item'>
@@ -148,6 +150,7 @@ class SideBar extends React.PureComponent<Props, State> {
     );
   }
 
+  // @ts-ignore is declared but its value is never read
   private renderWiki () {
     return null;
 

--- a/packages/joy-election/src/Applicant.tsx
+++ b/packages/joy-election/src/Applicant.tsx
@@ -2,9 +2,10 @@ import React from 'react';
 import { Link } from 'react-router-dom';
 import { Table } from 'semantic-ui-react';
 
-import { AccountId } from '@polkadot/types';
-import { BareProps, I18nProps } from '@polkadot/ui-app/types';
+import { I18nProps } from '@polkadot/ui-app/types';
+import { ApiProps } from '@polkadot/ui-api/types';
 import { withCalls } from '@polkadot/ui-api/with';
+import { AccountId } from '@polkadot/types';
 import { formatBalance } from '@polkadot/ui-app/util';
 import AddressMini from '@polkadot/ui-app/AddressMiniJoy';
 
@@ -12,7 +13,7 @@ import translate from './translate';
 import { calcTotalStake } from '@polkadot/joy-utils/index';
 import { Stake } from '@polkadot/joy-utils/types';
 
-type Props = BareProps & I18nProps & {
+type Props = ApiProps & I18nProps & {
   index: number,
   accountId: AccountId,
   stake?: Stake

--- a/packages/joy-election/src/Applicants.tsx
+++ b/packages/joy-election/src/Applicants.tsx
@@ -1,17 +1,17 @@
-import { ApiProps } from '@polkadot/ui-api/types';
-import { BareProps, I18nProps } from '@polkadot/ui-app/types';
-
 import React from 'react';
 import { Table } from 'semantic-ui-react';
-import { AccountId } from '@polkadot/types';
+
+import { I18nProps } from '@polkadot/ui-app/types';
+import { ApiProps } from '@polkadot/ui-api/types';
 import { withCalls } from '@polkadot/ui-api/with';
+import { AccountId } from '@polkadot/types';
 
 import translate from './translate';
 import Applicant from './Applicant';
 import ApplyForm from './ApplyForm';
 import Section from '@polkadot/joy-utils/Section';
 
-type Props = ApiProps & BareProps & I18nProps & {
+type Props = ApiProps & I18nProps & {
   applicants?: Array<AccountId>
 };
 

--- a/packages/joy-election/src/ApplyForm.tsx
+++ b/packages/joy-election/src/ApplyForm.tsx
@@ -1,6 +1,8 @@
 import BN from 'bn.js';
 import React from 'react';
 
+import { I18nProps } from '@polkadot/ui-app/types';
+import { ApiProps } from '@polkadot/ui-api/types';
 import { withCalls } from '@polkadot/ui-api/with';
 import { Labelled } from '@polkadot/ui-app/index';
 import { Balance } from '@polkadot/types';
@@ -10,7 +12,7 @@ import AccountSelector from '@polkadot/joy-utils/AccountSelector';
 import TxButton from '@polkadot/joy-utils/TxButton';
 import InputStake from '@polkadot/joy-utils/InputStake';
 
-type Props = {
+type Props = ApiProps & I18nProps & {
   minStake?: Balance
 };
 

--- a/packages/joy-election/src/Council.tsx
+++ b/packages/joy-election/src/Council.tsx
@@ -1,9 +1,9 @@
-import { ApiProps } from '@polkadot/ui-api/types';
-import { BareProps, I18nProps } from '@polkadot/ui-app/types';
-
 import React from 'react';
-import { Table } from 'semantic-ui-react';
+
+import { ApiProps } from '@polkadot/ui-api/types';
+import { I18nProps } from '@polkadot/ui-app/types';
 import { withCalls } from '@polkadot/ui-api/with';
+import { Table } from 'semantic-ui-react';
 import { formatBalance } from '@polkadot/ui-app/util';
 import AddressMini from '@polkadot/ui-app/AddressMiniJoy';
 
@@ -12,7 +12,7 @@ import { Seat } from '@polkadot/joy-utils/types';
 import translate from './translate';
 import Section from '@polkadot/joy-utils/Section';
 
-type Props = ApiProps & BareProps & I18nProps & {
+type Props = ApiProps & I18nProps & {
   council?: Seat[]
 };
 

--- a/packages/joy-election/src/Dashboard.tsx
+++ b/packages/joy-election/src/Dashboard.tsx
@@ -1,10 +1,10 @@
 import BN from 'bn.js';
 import React from 'react';
 
-import { BlockNumber, AccountId, Balance } from '@polkadot/types';
 import { ApiProps } from '@polkadot/ui-api/types';
-import { BareProps, I18nProps } from '@polkadot/ui-app/types';
+import { I18nProps } from '@polkadot/ui-app/types';
 import { withCalls } from '@polkadot/ui-api/with';
+import { BlockNumber, AccountId, Balance } from '@polkadot/types';
 import { Bubble } from '@polkadot/ui-app/index';
 import { formatNumber, formatBalance } from '@polkadot/ui-app/util';
 
@@ -13,7 +13,7 @@ import { queryToProp } from '@polkadot/joy-utils/index';
 import { ElectionStage, Seat, Announcing } from '@polkadot/joy-utils/types';
 import translate from './translate';
 
-type Props = BareProps & ApiProps & I18nProps & {
+type Props = ApiProps & I18nProps & {
   bestNumber?: BN,
 
   autoStartElections?: boolean,

--- a/packages/joy-election/src/Reveals.tsx
+++ b/packages/joy-election/src/Reveals.tsx
@@ -1,19 +1,19 @@
 import React from 'react';
-import queryString from 'query-string';
 
-import { AccountId } from '@polkadot/types';
-import { AppProps } from '@polkadot/ui-app/types';
+import { AppProps, I18nProps } from '@polkadot/ui-app/types';
+import { ApiProps } from '@polkadot/ui-api/types';
 import { withCalls } from '@polkadot/ui-api/with';
+import { AccountId } from '@polkadot/types';
 import { Input, Labelled, InputAddress } from '@polkadot/ui-app/index';
 
 import translate from './translate';
-import { nonEmptyStr, queryToProp } from '@polkadot/joy-utils/index';
+import { nonEmptyStr, queryToProp, getUrlParam } from '@polkadot/joy-utils/index';
 import { accountIdsToOptions, hashVote } from './utils';
 import AccountSelector from '@polkadot/joy-utils/AccountSelector';
 import TxButton from '@polkadot/joy-utils/TxButton';
 
 // AppsProps is needed to get a location from the route.
-type Props = AppProps & {
+type Props = AppProps & ApiProps & I18nProps & {
   accountId?: string,
   applicantId?: string,
   applicants?: AccountId[]
@@ -31,9 +31,8 @@ class App extends React.PureComponent<Props, State> {
   constructor (props: Props) {
     super(props);
     let { accountId, applicantId, location } = this.props;
-    const params = queryString.parse(location.search);
-    applicantId = applicantId ? applicantId : params.applicantId;
-    const { hashedVote } = params;
+    applicantId = applicantId ? applicantId : getUrlParam(location, 'applicantId');
+    const hashedVote = getUrlParam(location, 'hashedVote');
 
     this.state = {
       accountId,

--- a/packages/joy-election/src/SealedVote.tsx
+++ b/packages/joy-election/src/SealedVote.tsx
@@ -2,8 +2,10 @@ import React from 'react';
 import { Link } from 'react-router-dom';
 import { Table } from 'semantic-ui-react';
 
-import { Hash } from '@polkadot/types';
+import { I18nProps } from '@polkadot/ui-app/types';
+import { ApiProps } from '@polkadot/ui-api/types';
 import { withCalls } from '@polkadot/ui-api/with';
+import { Hash } from '@polkadot/types';
 import { formatBalance } from '@polkadot/ui-app/util';
 
 import translate from './translate';
@@ -11,7 +13,7 @@ import { calcTotalStake } from '@polkadot/joy-utils/index';
 import { SealedVote } from '@polkadot/joy-utils/types';
 import AddressMini from '@polkadot/ui-app/AddressMiniJoy';
 
-type Props = {
+type Props = ApiProps & I18nProps & {
   hash: Hash,
   sealedVote?: SealedVote
 };
@@ -69,7 +71,7 @@ class Comp extends React.PureComponent<Props, State> {
 // inject the actual API calls automatically into props
 export default translate(
   withCalls<Props>(
-    ['query.councilElection.votes', 
+    ['query.councilElection.votes',
       { paramName: 'hash', propName: 'sealedVote' }]
   )(Comp)
 );

--- a/packages/joy-election/src/SealedVotes.tsx
+++ b/packages/joy-election/src/SealedVotes.tsx
@@ -1,14 +1,15 @@
 import React from 'react';
 
-import { Hash } from '@polkadot/types';
-import { AppProps } from '@polkadot/ui-app/types';
+import { I18nProps } from '@polkadot/ui-app/types';
+import { ApiProps } from '@polkadot/ui-api/types';
 import { withCalls } from '@polkadot/ui-api/with';
+import { Hash } from '@polkadot/types';
 
 import translate from './translate';
 import SealedVote from './SealedVote';
 import { queryToProp } from '@polkadot/joy-utils/index';
 
-type Props = AppProps & {
+type Props = ApiProps & I18nProps & {
   commitments?: Hash[]
 };
 

--- a/packages/joy-election/src/Votes.tsx
+++ b/packages/joy-election/src/Votes.tsx
@@ -2,17 +2,17 @@ import BN from 'bn.js';
 import uuid from 'uuid/v4';
 
 import React from 'react';
-import queryString from 'query-string';
 import { Message } from 'semantic-ui-react';
 
-import { AccountId, Balance } from '@polkadot/types';
-import { AppProps } from '@polkadot/ui-app/types';
+import { AppProps, I18nProps } from '@polkadot/ui-app/types';
+import { ApiProps } from '@polkadot/ui-api/types';
 import { withCalls } from '@polkadot/ui-api/with';
+import { AccountId, Balance } from '@polkadot/types';
 import { Button, Input, Labelled, InputAddress } from '@polkadot/ui-app/index';
 
 import translate from './translate';
 import { accountIdsToOptions, hashVote } from './utils';
-import { queryToProp, ZERO } from '@polkadot/joy-utils/index';
+import { queryToProp, ZERO, getUrlParam } from '@polkadot/joy-utils/index';
 import SealedVotes from './SealedVotes';
 import AccountSelector from '@polkadot/joy-utils/AccountSelector';
 import TxButton from '@polkadot/joy-utils/TxButton';
@@ -25,7 +25,7 @@ function randomSalt () {
 }
 
 // AppsProps is needed to get a location from the route.
-type Props = AppProps & {
+type Props = AppProps & ApiProps & I18nProps & {
   accountId?: string,
   applicantId?: string,
   minVotingStake?: Balance,
@@ -47,8 +47,7 @@ class Component extends React.PureComponent<Props, State> {
     super(props);
 
     let { accountId, applicantId, location } = this.props;
-    const params = queryString.parse(location.search);
-    applicantId = applicantId ? applicantId : params.applicantId;
+    applicantId = applicantId ? applicantId : getUrlParam(location, 'applicantId');
 
     this.state = {
       accountId,

--- a/packages/joy-election/src/index.tsx
+++ b/packages/joy-election/src/index.tsx
@@ -1,9 +1,11 @@
 import React from 'react';
 import { Route, Switch } from 'react-router';
-import Tabs, { TabItem } from '@polkadot/ui-app/Tabs';
-import { withCalls } from '@polkadot/ui-api/with';
+
 import { AppProps, I18nProps } from '@polkadot/ui-app/types';
+import { ApiProps } from '@polkadot/ui-api/types';
+import { withCalls } from '@polkadot/ui-api/with';
 import { AccountId, Hash } from '@polkadot/types';
+import Tabs, { TabItem } from '@polkadot/ui-app/Tabs';
 
 // our app-specific styles
 import './index.css';
@@ -19,7 +21,7 @@ import { queryToProp } from '@polkadot/joy-utils/index';
 import { Seat } from '@polkadot/joy-utils/types';
 
 // define out internal types
-type Props = AppProps & I18nProps & {
+type Props = AppProps & ApiProps & I18nProps & {
   activeCouncil?: Seat[],
   applicants?: AccountId[],
   commitments?: Hash[]

--- a/packages/joy-proposals/src/List.tsx
+++ b/packages/joy-proposals/src/List.tsx
@@ -1,6 +1,8 @@
 import React from 'react';
 import { Table, Segment } from 'semantic-ui-react';
 
+import { I18nProps } from '@polkadot/ui-app/types';
+import { ApiProps } from '@polkadot/ui-api/types';
 import { withCalls } from '@polkadot/ui-api/with';
 import { u32 } from '@polkadot/types';
 
@@ -8,7 +10,7 @@ import translate from './translate';
 import { ProposalsMock, ProposalVotesMock } from './mocks';
 import AddressMini from '@polkadot/ui-app/AddressMiniJoy';
 
-type Props = {
+type Props = ApiProps & I18nProps & {
   proposalIds?: Uint32Array
 };
 
@@ -20,7 +22,7 @@ class Component extends React.PureComponent<Props, State> {
   state: State = {};
 
   render () {
-    let { proposalIds } = this.props;
+    // let { proposalIds } = this.props;
 
     return (
       <div className='ui list'>{ProposalsMock.map((proposal, i) => (

--- a/packages/joy-proposals/src/NewForm.tsx
+++ b/packages/joy-proposals/src/NewForm.tsx
@@ -1,8 +1,10 @@
 import BN from 'bn.js';
 import React from 'react';
 
-import { u8aToHex } from '@polkadot/util';
+import { I18nProps } from '@polkadot/ui-app/types';
+import { ApiProps } from '@polkadot/ui-api/types';
 import { withCalls } from '@polkadot/ui-api/with';
+import { u8aToHex } from '@polkadot/util';
 import { Input, InputFile, Labelled } from '@polkadot/ui-app/index';
 import { formatNumber } from '@polkadot/ui-app/util';
 import { Balance } from '@polkadot/types';
@@ -14,7 +16,7 @@ import TxButton from '@polkadot/joy-utils/TxButton';
 import InputStake from '@polkadot/joy-utils/InputStake';
 import TextArea from '@polkadot/joy-utils/TextArea';
 
-type Props = {
+type Props = ApiProps & I18nProps & {
   minStake?: Balance
 };
 
@@ -126,7 +128,12 @@ class Component extends React.PureComponent<Props, State> {
 
   private isFormValid = (): boolean => {
     const s = this.state;
-    return s.isStakeValid && s.isNameValid && s.isDescriptionValid && s.isWasmCodeValid;
+    return (
+      s.isStakeValid &&
+      s.isNameValid &&
+      s.isDescriptionValid &&
+      s.isWasmCodeValid
+    ) ? true : false;
   }
 }
 

--- a/packages/joy-utils/package.json
+++ b/packages/joy-utils/package.json
@@ -9,6 +9,8 @@
   "dependencies": {
     "@babel/runtime": "^7.2.0",
     "@polkadot/ui-app": "^0.23.11",
+    "@types/query-string": "^6.2.0",
+    "@types/uuid": "^3.4.4",
     "formik": "^1.5.0",
     "query-string": "^6.2.0",
     "unstated": "^2.1.1",

--- a/packages/joy-utils/src/index.ts
+++ b/packages/joy-utils/src/index.ts
@@ -99,3 +99,13 @@ export function queryToProp (apiQuery: string): [string, QueryOptions] {
   const propName = apiQuery.split('.').slice(-1)[0];
   return [apiQuery, { propName }];
 }
+
+// Parse URLs
+// --------------------------------------
+
+import queryString from 'query-string';
+
+export function getUrlParam (location: Location, paramName: string, deflt: string | undefined = undefined): string | undefined {
+  const params = queryString.parse(location.search);
+  return params[paramName] ? params[paramName] as string : deflt;
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -1988,6 +1988,11 @@
   resolved "https://registry.yarnpkg.com/@types/prop-types/-/prop-types-15.5.8.tgz#8ae4e0ea205fe95c3901a5a1df7f66495e3a56ce"
   integrity sha512-3AQoUxQcQtLHsK25wtTWIoIpgYjH3vSDroZOUr7PpCHw/jLY1RB9z9E8dBT/OSmwStVgkRNvdh+ZHNiomRieaw==
 
+"@types/query-string@^6.2.0":
+  version "6.2.0"
+  resolved "https://registry.yarnpkg.com/@types/query-string/-/query-string-6.2.0.tgz#ac1903ab175de7fd4a7bb703964c297eebddc8f7"
+  integrity sha512-dnYqKg7eZ+t7ZhCuBtwLxjqON8yXr27hiu3zXfPqxfJSbWUZNwwISE0BJUxghlcKsk4lZSp7bdFSJBJVNWBfmA==
+
 "@types/react-copy-to-clipboard@^4.2.6":
   version "4.2.6"
   resolved "https://registry.yarnpkg.com/@types/react-copy-to-clipboard/-/react-copy-to-clipboard-4.2.6.tgz#d1374550dec803f17f26ec71b62783c5737bfc02"
@@ -2164,6 +2169,13 @@
     "@types/node" "*"
     "@types/react" "*"
     csstype "^2.2.0"
+
+"@types/uuid@^3.4.4":
+  version "3.4.4"
+  resolved "https://registry.yarnpkg.com/@types/uuid/-/uuid-3.4.4.tgz#7af69360fa65ef0decb41fd150bf4ca5c0cefdf5"
+  integrity sha512-tPIgT0GUmdJQNSHxp0X2jnpQfBSTfGxUMc/2CXBU2mnyTFVYVa2ojpoQ74w0U2yn2vw3jnC640+77lkFFpdVDw==
+  dependencies:
+    "@types/node" "*"
 
 "@types/webassembly-js-api@^0.0.2":
   version "0.0.2"


### PR DESCRIPTION
The last annoying bug is:

![image](https://user-images.githubusercontent.com/153928/53191566-d4dcd980-3614-11e9-8d05-3c95258ea617.png)

It is related to type defs of react-dom lib. I have tried to `yarn upgrade @types/react@^16.8.4` because this version of type defs has fixed the issue, but after this command type defs of other react-related libs keep `@types/react@^16.8.2`. And then I see even more errors because `@types/react@^16.8.4` in the root conflicts with `@types/react@^16.8.2` in other react-related libs.