### PR TITLE
register Amount type

### DIFF
--- a/packages/joy-utils/src/types.ts
+++ b/packages/joy-utils/src/types.ts
@@ -2,6 +2,8 @@ import typeRegistry from '@polkadot/types/codec/typeRegistry';
 import { Enum, EnumType, Option } from '@polkadot/types/codec';
 import { BlockNumber, AccountId, Balance, Hash, u32, Text } from '@polkadot/types';
 
+class Amount extends Balance {};
+
 export type TransferableStake = {
   seat: Balance,
   backing: Balance
@@ -128,7 +130,9 @@ export function registerJoystreamTypes () {
       Revealing,
       ElectionStage
     });
-
+    typeRegistry.register({
+      Amount,
+    })
     typeRegistry.register({
       ProposalStatus,
       VoteKind


### PR DESCRIPTION
Add missing [Amount](https://github.com/polkadot-js/api/blob/master/packages/types/src/type/Amount.ts) type to work with latest substrate node.

This is only temporary until we merge from upstream.