### PR TITLE
add joy-settings module in place of ui-settings

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -2,7 +2,7 @@ const config = require('@polkadot/dev-react/config/jest');
 
 module.exports = Object.assign({}, config, {
   moduleNameMapper: {
-    '@polkadot/joy-(election|proposals|utils)(.*)$': '<rootDir>/packages/joy-$1/src/$2',
+    '@polkadot/joy-(election|proposals|utils|settings)(.*)$': '<rootDir>/packages/joy-$1/src/$2',
     '@polkadot/app-(123code|accounts|addresses|democracy|explorer|extrinsics|js|rpc|settings|staking|status|storage|toolbox|transfer)(.*)$': '<rootDir>/packages/app-$1/src/$2',
     '@polkadot/ui-(api|app|params|reactive|signer)(.*)$': '<rootDir>/packages/ui-$1/src/$2',
     '\\.(jpg|jpeg|png|gif|eot|otf|webp|svg|ttf|woff|woff2|mp4|webm|wav|mp3|m4a|aac|oga)$': 'empty/object',

--- a/packages/app-democracy/src/Referendum.tsx
+++ b/packages/app-democracy/src/Referendum.tsx
@@ -13,7 +13,7 @@ import { Chart, Static } from '@polkadot/ui-app/index';
 import VoteThreshold from '@polkadot/ui-params/Param/VoteThreshold';
 import { withCalls } from '@polkadot/ui-api/index';
 import { formatBalance, formatNumber } from '@polkadot/ui-app/util/index';
-import settings from '@polkadot/ui-settings';
+import settings from '@polkadot/joy-settings/index';
 
 import Item from './Item';
 import Voting from './Voting';

--- a/packages/app-settings/src/index.tsx
+++ b/packages/app-settings/src/index.tsx
@@ -4,14 +4,14 @@
 
 import { AppProps, I18nProps } from '@polkadot/ui-app/types';
 import { TabItem } from '@polkadot/ui-app/Tabs';
-import { SettingsStruct } from '@polkadot/ui-settings/types';
+import { SettingsStruct } from '@polkadot/joy-settings/types';
 
 import React from 'react';
 import { Route, Switch } from 'react-router';
 import store from 'store';
 import { typeRegistry } from '@polkadot/types';
 import { Button, Dropdown, Input, InputFile, Tabs } from '@polkadot/ui-app/index';
-import uiSettings from '@polkadot/ui-settings';
+import uiSettings from '@polkadot/joy-settings/index';
 import { u8aToString } from '@polkadot/util';
 
 import './index.css';

--- a/packages/apps/src/Connecting/index.tsx
+++ b/packages/apps/src/Connecting/index.tsx
@@ -9,7 +9,7 @@ import './Connecting.css';
 
 import React from 'react';
 import { withApi, withMulti } from '@polkadot/ui-api/index';
-import settings from '@polkadot/ui-settings';
+import settings from '@polkadot/joy-settings/index';
 
 import translate from '../translate';
 

--- a/packages/apps/src/SideBar/logos.ts
+++ b/packages/apps/src/SideBar/logos.ts
@@ -6,7 +6,7 @@ import polkadotLogo from '@polkadot/ui-assets/polkadot-white.svg';
 import polkadotSmall from '@polkadot/ui-assets/notext-polkadot.svg';
 import substrateLogo from '@polkadot/ui-assets/parity-substrate-white.svg';
 import substrateSmall from '@polkadot/ui-assets/notext-parity-substrate-white.svg';
-import settings from '@polkadot/ui-settings';
+import settings from '@polkadot/joy-settings/index';
 
 type LogoMap = Map<string, any>;
 

--- a/packages/apps/src/index.tsx
+++ b/packages/apps/src/index.tsx
@@ -12,7 +12,7 @@ import { typeRegistry } from '@polkadot/types';
 import createApp from '@polkadot/ui-app/index';
 import { classes } from '@polkadot/ui-app/util';
 import Signer from '@polkadot/ui-signer/index';
-import settings from '@polkadot/ui-settings';
+import settings from '@polkadot/joy-settings/index';
 
 import Connecting from './Connecting';
 import Content from './Content';

--- a/packages/apps/src/routing/index.ts
+++ b/packages/apps/src/routing/index.ts
@@ -4,7 +4,7 @@
 
 import { Routing, Routes } from '../types';
 
-import appSettings from '@polkadot/ui-settings';
+import appSettings from '@polkadot/joy-settings/index';
 
 import election from './joy-election';
 import proposals from './joy-proposals';

--- a/packages/apps/webpack.config.js
+++ b/packages/apps/webpack.config.js
@@ -17,6 +17,7 @@ const packages = [
   'joy-election',
   'joy-proposals',
   'joy-utils',
+  'joy-settings',
 
   // Polkadot apps:
 
@@ -39,9 +40,7 @@ const packages = [
   'ui-signer'
 ];
 
-const DEFAULT_THEME = process.env.TRAVIS_BRANCH === 'next'
-  ? 'substrate'
-  : 'polkadot';
+const DEFAULT_THEME = 'substrate';
 
 function createWebpack ({ alias = {}, context, name = 'index' }) {
   const pkgJson = require(path.join(context, 'package.json'));
@@ -186,7 +185,7 @@ function createWebpack ({ alias = {}, context, name = 'index' }) {
         'process.env': {
           NODE_ENV: JSON.stringify(ENV),
           VERSION: JSON.stringify(pkgJson.version),
-          UI_MODE: JSON.stringify(process.env.UI_MODE || 'full'),
+          UI_MODE: JSON.stringify(process.env.UI_MODE || 'light'),
           UI_THEME: JSON.stringify(process.env.UI_THEME || DEFAULT_THEME),
           WS_URL: JSON.stringify(process.env.WS_URL)
         }

--- a/packages/joy-settings/LICENSE
+++ b/packages/joy-settings/LICENSE
@@ -1,0 +1,201 @@
+                              Apache License
+                        Version 2.0, January 2004
+                    http://www.apache.org/licenses/
+
+TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+1. Definitions.
+
+  "License" shall mean the terms and conditions for use, reproduction,
+  and distribution as defined by Sections 1 through 9 of this document.
+
+  "Licensor" shall mean the copyright owner or entity authorized by
+  the copyright owner that is granting the License.
+
+  "Legal Entity" shall mean the union of the acting entity and all
+  other entities that control, are controlled by, or are under common
+  control with that entity. For the purposes of this definition,
+  "control" means (i) the power, direct or indirect, to cause the
+  direction or management of such entity, whether by contract or
+  otherwise, or (ii) ownership of fifty percent (50%) or more of the
+  outstanding shares, or (iii) beneficial ownership of such entity.
+
+  "You" (or "Your") shall mean an individual or Legal Entity
+  exercising permissions granted by this License.
+
+  "Source" form shall mean the preferred form for making modifications,
+  including but not limited to software source code, documentation
+  source, and configuration files.
+
+  "Object" form shall mean any form resulting from mechanical
+  transformation or translation of a Source form, including but
+  not limited to compiled object code, generated documentation,
+  and conversions to other media types.
+
+  "Work" shall mean the work of authorship, whether in Source or
+  Object form, made available under the License, as indicated by a
+  copyright notice that is included in or attached to the work
+  (an example is provided in the Appendix below).
+
+  "Derivative Works" shall mean any work, whether in Source or Object
+  form, that is based on (or derived from) the Work and for which the
+  editorial revisions, annotations, elaborations, or other modifications
+  represent, as a whole, an original work of authorship. For the purposes
+  of this License, Derivative Works shall not include works that remain
+  separable from, or merely link (or bind by name) to the interfaces of,
+  the Work and Derivative Works thereof.
+
+  "Contribution" shall mean any work of authorship, including
+  the original version of the Work and any modifications or additions
+  to that Work or Derivative Works thereof, that is intentionally
+  submitted to Licensor for inclusion in the Work by the copyright owner
+  or by an individual or Legal Entity authorized to submit on behalf of
+  the copyright owner. For the purposes of this definition, "submitted"
+  means any form of electronic, verbal, or written communication sent
+  to the Licensor or its representatives, including but not limited to
+  communication on electronic mailing lists, source code control systems,
+  and issue tracking systems that are managed by, or on behalf of, the
+  Licensor for the purpose of discussing and improving the Work, but
+  excluding communication that is conspicuously marked or otherwise
+  designated in writing by the copyright owner as "Not a Contribution."
+
+  "Contributor" shall mean Licensor and any individual or Legal Entity
+  on behalf of whom a Contribution has been received by Licensor and
+  subsequently incorporated within the Work.
+
+2. Grant of Copyright License. Subject to the terms and conditions of
+  this License, each Contributor hereby grants to You a perpetual,
+  worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+  copyright license to reproduce, prepare Derivative Works of,
+  publicly display, publicly perform, sublicense, and distribute the
+  Work and such Derivative Works in Source or Object form.
+
+3. Grant of Patent License. Subject to the terms and conditions of
+  this License, each Contributor hereby grants to You a perpetual,
+  worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+  (except as stated in this section) patent license to make, have made,
+  use, offer to sell, sell, import, and otherwise transfer the Work,
+  where such license applies only to those patent claims licensable
+  by such Contributor that are necessarily infringed by their
+  Contribution(s) alone or by combination of their Contribution(s)
+  with the Work to which such Contribution(s) was submitted. If You
+  institute patent litigation against any entity (including a
+  cross-claim or counterclaim in a lawsuit) alleging that the Work
+  or a Contribution incorporated within the Work constitutes direct
+  or contributory patent infringement, then any patent licenses
+  granted to You under this License for that Work shall terminate
+  as of the date such litigation is filed.
+
+4. Redistribution. You may reproduce and distribute copies of the
+  Work or Derivative Works thereof in any medium, with or without
+  modifications, and in Source or Object form, provided that You
+  meet the following conditions:
+
+  (a) You must give any other recipients of the Work or
+      Derivative Works a copy of this License; and
+
+  (b) You must cause any modified files to carry prominent notices
+      stating that You changed the files; and
+
+  (c) You must retain, in the Source form of any Derivative Works
+      that You distribute, all copyright, patent, trademark, and
+      attribution notices from the Source form of the Work,
+      excluding those notices that do not pertain to any part of
+      the Derivative Works; and
+
+  (d) If the Work includes a "NOTICE" text file as part of its
+      distribution, then any Derivative Works that You distribute must
+      include a readable copy of the attribution notices contained
+      within such NOTICE file, excluding those notices that do not
+      pertain to any part of the Derivative Works, in at least one
+      of the following places: within a NOTICE text file distributed
+      as part of the Derivative Works; within the Source form or
+      documentation, if provided along with the Derivative Works; or,
+      within a display generated by the Derivative Works, if and
+      wherever such third-party notices normally appear. The contents
+      of the NOTICE file are for informational purposes only and
+      do not modify the License. You may add Your own attribution
+      notices within Derivative Works that You distribute, alongside
+      or as an addendum to the NOTICE text from the Work, provided
+      that such additional attribution notices cannot be construed
+      as modifying the License.
+
+  You may add Your own copyright statement to Your modifications and
+  may provide additional or different license terms and conditions
+  for use, reproduction, or distribution of Your modifications, or
+  for any such Derivative Works as a whole, provided Your use,
+  reproduction, and distribution of the Work otherwise complies with
+  the conditions stated in this License.
+
+5. Submission of Contributions. Unless You explicitly state otherwise,
+  any Contribution intentionally submitted for inclusion in the Work
+  by You to the Licensor shall be under the terms and conditions of
+  this License, without any additional terms or conditions.
+  Notwithstanding the above, nothing herein shall supersede or modify
+  the terms of any separate license agreement you may have executed
+  with Licensor regarding such Contributions.
+
+6. Trademarks. This License does not grant permission to use the trade
+  names, trademarks, service marks, or product names of the Licensor,
+  except as required for reasonable and customary use in describing the
+  origin of the Work and reproducing the content of the NOTICE file.
+
+7. Disclaimer of Warranty. Unless required by applicable law or
+  agreed to in writing, Licensor provides the Work (and each
+  Contributor provides its Contributions) on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+  implied, including, without limitation, any warranties or conditions
+  of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+  PARTICULAR PURPOSE. You are solely responsible for determining the
+  appropriateness of using or redistributing the Work and assume any
+  risks associated with Your exercise of permissions under this License.
+
+8. Limitation of Liability. In no event and under no legal theory,
+  whether in tort (including negligence), contract, or otherwise,
+  unless required by applicable law (such as deliberate and grossly
+  negligent acts) or agreed to in writing, shall any Contributor be
+  liable to You for damages, including any direct, indirect, special,
+  incidental, or consequential damages of any character arising as a
+  result of this License or out of the use or inability to use the
+  Work (including but not limited to damages for loss of goodwill,
+  work stoppage, computer failure or malfunction, or any and all
+  other commercial damages or losses), even if such Contributor
+  has been advised of the possibility of such damages.
+
+9. Accepting Warranty or Additional Liability. While redistributing
+  the Work or Derivative Works thereof, You may choose to offer,
+  and charge a fee for, acceptance of support, warranty, indemnity,
+  or other liability obligations and/or rights consistent with this
+  License. However, in accepting such obligations, You may act only
+  on Your own behalf and on Your sole responsibility, not on behalf
+  of any other Contributor, and only if You agree to indemnify,
+  defend, and hold each Contributor harmless for any liability
+  incurred by, or claims asserted against, such Contributor by reason
+  of your accepting any such warranty or additional liability.
+
+END OF TERMS AND CONDITIONS
+
+APPENDIX: How to apply the Apache License to your work.
+
+  To apply the Apache License to your work, attach the following
+  boilerplate notice, with the fields enclosed by brackets "[]"
+  replaced with your own identifying information. (Don't include
+  the brackets!)  The text should be enclosed in the appropriate
+  comment syntax for the file format. We also recommend that a
+  file or class name and description of purpose be included on the
+  same "printed page" as the copyright notice for easier
+  identification within third-party archives.
+
+Copyright [yyyy] [name of copyright owner]
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.

--- a/packages/joy-settings/README.md
+++ b/packages/joy-settings/README.md
@@ -1,0 +1,36 @@
+# @polkadot/ui-settings
+
+Manages app settings including endpoints, themes and prefixes
+
+### Usage Example
+User preferences are set as a settings object in the browser's local storage.
+```
+import settings from '@polkadot/ui-settings';
+
+render () {
+  // get api endpoint for the selected chain
+  const WS_URL = settings.apiUrl();
+
+  // get the selected il8n language
+  const language = settings.il8nLang();
+
+  // get all available il8n languages
+  const languages = settings.availableLanguages();
+
+  // update settings
+  const updatedSettings = {
+    ...settings,
+    i18nLang: 'Arabic'
+  }
+  settings.set(updatedSettings);
+
+  // NOTE: API currently does not handle hot reconnecting properly,
+  so you need to manually reload the page after updating settings.
+  window.location.reload();
+}
+```
+
+### Used by
+Apps that currently use the settings package
+* [polkadot-js/apps]('https://www.github.com/polkadot-js/apps')
+* [paritytech/substrate-light-ui](https://github.com/paritytech/substrate-light-ui)

--- a/packages/joy-settings/package.json
+++ b/packages/joy-settings/package.json
@@ -1,0 +1,16 @@
+{
+  "name": "@polkadot/joy-settings",
+  "version": "1.0.0",
+  "description": "Manages app settings",
+  "main": "index.js",
+  "author": "Jaco Greeff <jacogr@gmail.com>",
+  "maintainers": [
+    "Jaco Greeff <jacogr@gmail.com>"
+  ],
+  "license": "Apache-2.0",
+  "dependencies": {
+    "@babel/runtime": "^7.3.1",
+    "@types/store": "^2.0.1",
+    "store": "^2.0.12"
+  }
+}

--- a/packages/joy-settings/src/defaults.ts
+++ b/packages/joy-settings/src/defaults.ts
@@ -1,0 +1,30 @@
+// Copyright 2017-2019 @polkadot/ui-settings authors & contributors
+// This software may be modified and distributed under the terms
+// of the Apache-2.0 license. See the LICENSE file for details.
+
+import { Options } from './types';
+
+const ENDPOINTS: Options = [
+  { text: 'Joystream Testnet (hosted by joystream.org)', value: 'wss://sparta.joystream.org/rpc/' },
+  { text: 'Local Node (127.0.0.1:9944)', value: 'ws://127.0.0.1:9944/' }
+];
+
+const LANGUAGES: Options = [
+  { value: 'default', text: 'Default browser language (auto-detect)' }
+];
+
+const UIMODES: Options = [
+  { value: 'light', text: 'Basic features only' },
+  { value: 'full', text: 'Fully featured' }
+];
+
+const UITHEMES: Options = [
+  { value: 'substrate', text: 'Substrate' }
+];
+
+export {
+  ENDPOINTS,
+  LANGUAGES,
+  UIMODES,
+  UITHEMES
+};

--- a/packages/joy-settings/src/index.ts
+++ b/packages/joy-settings/src/index.ts
@@ -1,0 +1,82 @@
+// Copyright 2017-2019 @polkadot/ui-settings authors & contributors
+// This software may be modified and distributed under the terms
+// of the Apache-2.0 license. See the LICENSE file for details.
+
+import store from 'store';
+
+import { ENDPOINTS, LANGUAGES, UIMODES, UITHEMES } from './defaults';
+import { Options, SettingsStruct } from './types';
+
+class Settings implements SettingsStruct {
+  private _apiUrl: string;
+  private _i18nLang: string;
+  private _uiMode: string;
+  private _uiTheme: string;
+
+  constructor () {
+    const settings = store.get('settings') || {};
+
+    this._apiUrl = settings.apiUrl || process.env.WS_URL || ENDPOINTS[0].value;
+    this._i18nLang = settings.i18nLang || LANGUAGES[0].value;
+    this._uiMode = settings.uiMode || process.env.UI_MODE || UIMODES[0].value;
+    this._uiTheme = settings.uiTheme || process.env.UI_THEME || UITHEMES[0].value;
+  }
+
+  get apiUrl (): string {
+    return this._apiUrl;
+  }
+
+  get i18nLang (): string {
+    return this._i18nLang;
+  }
+
+  get uiMode (): string {
+    return this._uiMode;
+  }
+
+  get uiTheme (): string {
+    return this._uiTheme;
+  }
+
+  get availableNodes (): Options {
+    return ENDPOINTS;
+  }
+
+  get availableChains (): Options {
+    return [];
+  }
+
+  get availableLanguages (): Options {
+    return LANGUAGES;
+  }
+
+  get availableUIModes (): Options {
+    return UIMODES;
+  }
+
+  get availableUIThemes (): Options {
+    return UITHEMES;
+  }
+
+  get (): SettingsStruct {
+    return {
+      apiUrl: this._apiUrl,
+      i18nLang: this._i18nLang,
+      uiMode: this._uiMode,
+      uiTheme: this._uiTheme
+    };
+  }
+
+  set (settings: Partial<SettingsStruct>): void {
+    this._apiUrl = settings.apiUrl || this._apiUrl;
+    this._i18nLang = settings.i18nLang || this._i18nLang;
+    this._uiMode = settings.uiMode || this._uiMode;
+    this._uiTheme = settings.uiTheme || this._uiTheme;
+
+    store.set('settings', this.get());
+  }
+}
+
+const settings = new Settings();
+
+export default settings;

--- a/packages/joy-settings/src/types.ts
+++ b/packages/joy-settings/src/types.ts
@@ -1,0 +1,16 @@
+// Copyright 2017-2019 @polkadot/ui-settings authors & contributors
+// This software may be modified and distributed under the terms
+// of the Apache-2.0 license. See the LICENSE file for details.
+
+export type Options = Array<{
+  disabled?: boolean,
+  text: string,
+  value: string
+}>;
+
+export interface SettingsStruct {
+  apiUrl: string;
+  i18nLang: string;
+  uiMode: string;
+  uiTheme: string;
+}

--- a/packages/ui-api/src/Api.tsx
+++ b/packages/ui-api/src/Api.tsx
@@ -13,7 +13,6 @@ import { WsProvider } from '@polkadot/rpc-provider';
 import { InputNumber } from '@polkadot/ui-app/InputNumber';
 import { formatBalance } from '@polkadot/ui-app/util';
 import keyring from '@polkadot/ui-keyring';
-import settings from '@polkadot/ui-settings';
 import ApiSigner from '@polkadot/ui-signer/ApiSigner';
 import { ChainProperties } from '@polkadot/types';
 
@@ -89,23 +88,19 @@ export default class ApiWrapper extends React.PureComponent<Props, State> {
     const chain = value
       ? value.toString()
       : null;
-    const found = settings.availableChains.find(({ name }) => name === chain) || {
-      networkId: 42,
-      tokenDecimals: 0,
-      tokenSymbol: undefined
-    };
-    const tokenSymbol = properties.get('tokenSymbol') || found.tokenSymbol;
+
+    const tokenSymbol = properties.get('tokenSymbol');
     const isDevelopment = isTestChain(chain);
 
     console.log('api: found chain', chain, [...properties.entries()]);
 
     // first setup the UI helpers
-    formatBalance.setDefaultDecimals(properties.get('tokenDecimals') || found.tokenDecimals);
+    formatBalance.setDefaultDecimals(properties.get('tokenDecimals') || 0);
     formatBalance.setDefaultUnits(tokenSymbol);
     InputNumber.setUnit(tokenSymbol);
 
     keyring.loadAll({
-      addressPrefix: properties.get('networkId') || found.networkId as any,
+      addressPrefix: properties.get('networkId') || 42 as any,
       isDevelopment,
       type: 'ed25519'
     });

--- a/packages/ui-app/package.json
+++ b/packages/ui-app/package.json
@@ -17,7 +17,7 @@
     "@polkadot/ui-identicon": "^0.26.3",
     "@polkadot/ui-keyring": "^0.26.3",
     "@polkadot/ui-reactive": "^0.23.29",
-    "@polkadot/ui-settings": "^0.26.3",
+    "@polkadot/joy-settings": "^1.0.0",
     "@polkadot/util": "^0.34.15",
     "@polkadot/util-crypto": "^0.34.15",
     "@types/chart.js": "^2.7.45",

--- a/packages/ui-app/src/Bubble.tsx
+++ b/packages/ui-app/src/Bubble.tsx
@@ -7,7 +7,7 @@ import { SemanticCOLORS, SemanticICONS } from 'semantic-ui-react/dist/commonjs/g
 
 import React from 'react';
 import SUILabel from 'semantic-ui-react/dist/commonjs/elements/Label/Label';
-import settings from '@polkadot/ui-settings';
+import settings from '@polkadot/joy-settings/index';
 
 import classes from './util/classes';
 import Icon from './Icon';

--- a/packages/ui-app/src/Modal.tsx
+++ b/packages/ui-app/src/Modal.tsx
@@ -6,7 +6,7 @@ import { BareProps } from './types';
 
 import React from 'react';
 import SUIModal from 'semantic-ui-react/dist/commonjs/modules/Modal/Modal';
-import settings from '@polkadot/ui-settings';
+import settings from '@polkadot/joy-settings/index';
 
 import classes from './util/classes';
 

--- a/packages/ui-app/src/index.tsx
+++ b/packages/ui-app/src/index.tsx
@@ -2,7 +2,7 @@
 // This software may be modified and distributed under the terms
 // of the Apache-2.0 license. See the LICENSE file for details.
 
-import '@polkadot/ui-settings';
+import '@polkadot/joy-settings/index';
 import './i18n';
 import './styles';
 

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -9,7 +9,8 @@
       "@polkadot/joy-election/*": [ "packages/joy-election/src/*" ],
       "@polkadot/joy-proposals/*": [ "packages/joy-proposals/src/*" ],
       "@polkadot/joy-utils/*": [ "packages/joy-utils/src/*" ],
-      
+      "@polkadot/joy-settings/*": [ "packages/joy-settings/src/*" ],
+
       "@polkadot/app-123code/*": [ "packages/app-123code/src/*" ],
       "@polkadot/app-accounts/*": [ "packages/app-accounts/src/*" ],
       "@polkadot/app-addresses/*": [ "packages/app-addresses/src/*" ],
@@ -27,7 +28,7 @@
       "@polkadot/ui-app/*": [ "packages/ui-app/src/*" ],
       "@polkadot/ui-params/*": [ "packages/ui-params/src/*" ],
       "@polkadot/ui-reactive/*": [ "packages/ui-reactive/src/*" ],
-      "@polkadot/ui-signer/*": [ "packages/ui-signer/src/*" ]
+      "@polkadot/ui-signer/*": [ "packages/ui-signer/src/*" ],
     },
     "typeRoots": [
       "./node_modules/@polkadot/ts",


### PR DESCRIPTION
Imported the current version of `@polkadot/ui-settings` into the workspace and renamed it to `@polkadot/joy-settings` (to configure nodes and  ui_theme etc..)

A better solution would be to add methods on ui-settings package to add/remove nodes, or to be configurable in webpack config file. 

Since we need this now it will have to do. 