### PR TITLE
UX: add election stage name below "Council" sidebar item

### DIFF
--- a/packages/apps/src/SideBar/Item.tsx
+++ b/packages/apps/src/SideBar/Item.tsx
@@ -12,15 +12,20 @@ import React from 'react';
 import { NavLink } from 'react-router-dom';
 import { Icon, Menu } from '@polkadot/ui-app';
 import accountObservable from '@polkadot/ui-keyring/observable/accounts';
-import { withApi, withMulti, withObservable } from '@polkadot/ui-api';
+import { withApi, withCalls, withMulti, withObservable } from '@polkadot/ui-api';
 import { isFunction } from '@polkadot/util';
+import { Option } from '@polkadot/types';
 
 import ReactTooltip from 'react-tooltip';
+import { queryToProp } from '@polkadot/joy-utils/index';
+import { ElectionStage } from '@polkadot/joy-utils/types';
+import { councilSidebarName } from '../routing/joy-election';
 
 type Props = I18nProps & ApiProps & {
   isCollapsed: boolean,
   onClick: () => void,
   allAccounts?: SubjectInfo,
+  electionStage: Option<ElectionStage>,
   route: Route
 };
 
@@ -29,6 +34,11 @@ interface Tooltip {
   'data-for': string;
   'data-tip-disable'?: boolean;
 }
+
+type Subtitle = {
+  text: string,
+  classes: string[]
+};
 
 class Item extends React.PureComponent<Props> {
   componentWillUpdate () {
@@ -42,6 +52,8 @@ class Item extends React.PureComponent<Props> {
     if (!this.isVisible()) {
       return null;
     }
+
+    const subtitle = this.getSubtitle(name);
 
     const tooltip: Tooltip = {
       'data-for': `nav-${name}`,
@@ -59,7 +71,10 @@ class Item extends React.PureComponent<Props> {
           {...tooltip}
         >
           <Icon name={icon} />
-          <span className='text'>{t(`sidebar.${name}`, i18n)}</span>
+          <div className='text SidebarItem'>
+            <div>{t(`sidebar.${name}`, i18n)}</div>
+            {subtitle && <div className={`SidebarSubtitle ${subtitle.classes.join(' ')}`}>{subtitle.text}</div>}
+          </div>
           <ReactTooltip
            delayShow={750}
            effect='solid'
@@ -73,6 +88,24 @@ class Item extends React.PureComponent<Props> {
         </NavLink>
       </Menu.Item>
     );
+  }
+
+  private getSubtitle (name: string): Subtitle | undefined {
+    if (name === councilSidebarName) {
+      const { electionStage: stage } = this.props;
+      if (stage && stage.isSome) {
+        const classes: string[] = [];
+        let text = 'No active election';
+        if (stage.isSome) {
+          const stageValue = stage.value as ElectionStage;
+          const stageName = stageValue.type;
+          text = `${stageName} stage`;
+          classes.push(stageName);
+        }
+        return { text, classes };
+      }
+    }
+    return undefined;
   }
 
   private hasApi (endpoint: string): boolean {
@@ -119,5 +152,6 @@ class Item extends React.PureComponent<Props> {
 export default withMulti(
   Item,
   withApi,
+  withCalls(queryToProp('query.councilElection.stage', { propName: 'electionStage' })),
   withObservable(accountObservable.subject, { propName: 'allAccounts' })
 );

--- a/packages/apps/src/routing/joy-election.ts
+++ b/packages/apps/src/routing/joy-election.ts
@@ -2,6 +2,8 @@ import { Routes } from '../types';
 
 import Election from '@polkadot/joy-election/index';
 
+export const councilSidebarName = 'council';
+
 export default ([
   {
     Component: Election,
@@ -15,6 +17,6 @@ export default ([
       defaultValue: 'Council'
     },
     icon: 'university',
-    name: 'council'
+    name: councilSidebarName
   }
 ] as Routes);

--- a/packages/joy-election/src/index.css
+++ b/packages/joy-election/src/index.css
@@ -14,3 +14,15 @@
     font-weight: normal !important;
   }
 }
+
+.SidebarSubtitle {
+  &.Announcing {
+    color: #4caf50; /* green */
+  }
+  &.Voting {
+    color: #2196f3; /* blue */
+  }
+  &.Revealing {
+    color: #ff5722; /* red */
+  }
+}

--- a/packages/ui-app/src/styles/joystream.css
+++ b/packages/ui-app/src/styles/joystream.css
@@ -70,6 +70,17 @@
   }
 }
 
+.SidebarItem {
+  display: inline-flex;
+  flex-direction: column;
+
+  .SidebarSubtitle {
+    display: block;
+    font-size: 0.85rem;
+    color: grey;
+  }
+}
+
 .JoySection {
   margin-top: 2rem;
   margin-bottom: 1rem;


### PR DESCRIPTION
Such as it's very important to take part in every stage of the election (especially `Revealing`), I thought that it will help by adding a name of a current stage as a subtitle to sidebar below "Council" item. Below are the screenshots what this PR brings to UI:
 
![image](https://user-images.githubusercontent.com/153928/56161677-6e4bba80-5fca-11e9-8e61-2f76504c4eaa.png)

![image](https://user-images.githubusercontent.com/153928/56161662-655ae900-5fca-11e9-9da6-88aabf2c9599.png)

![image](https://user-images.githubusercontent.com/153928/56161713-83c0e480-5fca-11e9-8dfd-cc86adf84fbe.png)

![image](https://user-images.githubusercontent.com/153928/56161755-a3f0a380-5fca-11e9-8e55-4e804e0373f7.png)
