### PR TITLE
UUID fix

### DIFF
--- a/packages/joy-media/src/Upload.tsx
+++ b/packages/joy-media/src/Upload.tsx
@@ -22,7 +22,7 @@ import TxButton from '@polkadot/joy-utils/TxButton';
 const MAX_FILE_SIZE_200_MB = 200 * 1024 * 1024;
 
 function generateContentId () {
-  const uuid = uuidv4().replace('-', '');
+  const uuid = uuidv4().replace(/-/g, '');
   return new ContentId(stringToU8a(uuid));
 }
 


### PR DESCRIPTION
The current code replaces the first '-', leading to a content ID that still contains '-', but has the last few random bytes cut off. It'd be better to keep the random bytes, and discard all dashes.