### PR TITLE
Make joy-types package into a reusable standalone npm package

### DIFF
--- a/packages/joy-types/README.md
+++ b/packages/joy-types/README.md
@@ -1,6 +1,6 @@
 # `@joystream/types`
 
-The types packages is required to register the custom substrate runtime types when working with [`@polkadot/api`](https://www.npmjs.com/package/@polkadot/api#registering-custom-types) to communicate with a joystream full node.
+The types package is required to register the custom Substrate runtime types when working with [`@polkadot/api`](https://www.npmjs.com/package/@polkadot/api#registering-custom-types) to communicate with a Joystream full node.
 
 
 ## Installation

--- a/packages/joy-types/README.md
+++ b/packages/joy-types/README.md
@@ -17,7 +17,7 @@ npm install --save @joystream/types
 
 ## Registering the types
 
-Call `registerJoystreamTypes()` before creating a polkadot api client.
+Call `registerJoystreamTypes()` before creating a Polkadot API client.
 
 ```javascript
 import { registerJoystreamTypes } from '@joystream/types';

--- a/packages/joy-types/README.md
+++ b/packages/joy-types/README.md
@@ -1,0 +1,51 @@
+# `@joystream/types`
+
+The types packages is required to register the custom substrate runtime types when working with [`@polkadot/api`](https://www.npmjs.com/package/@polkadot/api#registering-custom-types) to communicate with a joystream full node.
+
+
+## Installation
+
+Add the package as a dependency in your project.
+
+```shell
+yarn add @joystream/types
+
+or
+
+npm install --save @joystream/types
+```
+
+## Registering the types
+
+Call `registerJoystreamTypes()` before creating a polkadot api client.
+
+```javascript
+import { registerJoystreamTypes } from '@joystream/types';
+import { ApiPromise, WsProvider } from '@polkadot/api';
+
+async function main () {
+  // Initialise the provider to connect to the local node
+  const provider = new WsProvider('ws://127.0.0.1:9944');
+
+  // Register types before creating the API
+  registerJoystreamTypes();
+
+  // Create the API and wait until ready
+  const api = await ApiPromise.create(provider);
+
+  // Retrieve the chain & node information information via rpc calls
+  const [chain, nodeName, nodeVersion] = await Promise.all([
+    api.rpc.system.chain(),
+    api.rpc.system.name(),
+    api.rpc.system.version()
+  ]);
+
+  console.log(`Chain ${chain} using ${nodeName} v${nodeVersion}`);
+}
+
+main();
+```
+
+## Users
+
+See [joystream-api-examples](https://github.com/Joystream/joystream-api-examples) for some additional examples on usage.

--- a/packages/joy-types/README.md
+++ b/packages/joy-types/README.md
@@ -10,7 +10,7 @@ Add the package as a dependency in your project.
 ```shell
 yarn add @joystream/types
 
-or
+# or
 
 npm install --save @joystream/types
 ```

--- a/packages/joy-types/README.md
+++ b/packages/joy-types/README.md
@@ -33,7 +33,7 @@ async function main () {
   // Create the API and wait until ready
   const api = await ApiPromise.create(provider);
 
-  // Retrieve the chain & node information information via rpc calls
+  // Retrieve the chain & node information information via RPC calls
   const [chain, nodeName, nodeVersion] = await Promise.all([
     api.rpc.system.chain(),
     api.rpc.system.name(),

--- a/packages/joy-types/package.json
+++ b/packages/joy-types/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@joystream/types",
-  "version": "0.1.2",
+  "version": "0.1.3",
   "description": "Joystream types for Substrate modules",
   "main": "lib/index.js",
   "scripts": {
@@ -15,5 +15,23 @@
     "@polkadot/util": "^0.76.1",
     "@polkadot/util-crypto": "^0.76.1",
     "typescript": "^3.4.5"
-  }
+  },
+  "directories": {
+    "lib": "lib"
+  },
+  "devDependencies": {},
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/Joystream/apps.git"
+  },
+  "keywords": [
+    "substrate",
+    "joystream",
+    "runtime"
+  ],
+  "license": "Apache-2.0",
+  "bugs": {
+    "url": "https://github.com/Joystream/apps/issues"
+  },
+  "homepage": "https://github.com/Joystream/apps#readme"
 }

--- a/packages/joy-types/package.json
+++ b/packages/joy-types/package.json
@@ -2,13 +2,18 @@
   "name": "@joystream/types",
   "version": "0.1.0",
   "description": "Joystream types for Substrate modules",
-  "scripts": {},
+  "main": "src/index.js",
+  "scripts": {
+    "postinstall": "npm run build",
+    "build": "tsc --build tsconfig.json"
+  },
   "author": "Joystream contributors",
   "maintainers": [],
   "dependencies": {
     "@polkadot/keyring": "^0.76.1",
     "@polkadot/types": "^0.77.0-beta.4",
     "@polkadot/util": "^0.76.1",
-    "@polkadot/util-crypto": "^0.76.1"
+    "@polkadot/util-crypto": "^0.76.1",
+    "typescript": "^3.4.5"
   }
 }

--- a/packages/joy-types/package.json
+++ b/packages/joy-types/package.json
@@ -1,8 +1,8 @@
 {
   "name": "@joystream/types",
-  "version": "0.1.0",
+  "version": "0.1.2",
   "description": "Joystream types for Substrate modules",
-  "main": "src/index.js",
+  "main": "lib/index.js",
   "scripts": {
     "postinstall": "npm run build",
     "build": "tsc --build tsconfig.json"

--- a/packages/joy-types/package.json
+++ b/packages/joy-types/package.json
@@ -33,5 +33,5 @@
   "bugs": {
     "url": "https://github.com/Joystream/apps/issues"
   },
-  "homepage": "https://github.com/Joystream/apps#readme"
+  "homepage": "https://github.com/Joystream/packages/joy-types/README.md"
 }

--- a/packages/joy-types/src/media.ts
+++ b/packages/joy-types/src/media.ts
@@ -1,6 +1,6 @@
 import { Enum, Struct, Option, Vector } from '@polkadot/types/codec';
 import { getTypeRegistry, u64, Bool, Text, BlockNumber, Moment, AccountId, Hash } from '@polkadot/types';
-import { OptionText } from '@joystream/types/';
+import { OptionText } from './';
 
 import { randomAsU8a } from '@polkadot/util-crypto';
 import { encodeAddress, decodeAddress } from '@polkadot/keyring';

--- a/packages/joy-types/tsconfig.json
+++ b/packages/joy-types/tsconfig.json
@@ -10,10 +10,12 @@
     "allowSyntheticDefaultImports": true,     /* Allow default imports from modules with no default export. This does not affect code emit, just typechecking. */
     "esModuleInterop": true,                  /* Enables emit interoperability between CommonJS and ES Modules via creation of namespace objects for all imports. Implies 'allowSyntheticDefaultImports'. */
     "experimentalDecorators": true,           /* Enables experimental support for ES7 decorators. */
-
+    "declaration": true,
+    "outDir": "lib",
     "typeRoots": [
       "./node_modules/@polkadot/ts",
-      "./node_modules/@types"
+      "./node_modules/@types",
+      "./lib"
     ]
   },
   "include": [

--- a/packages/joy-types/tsconfig.json
+++ b/packages/joy-types/tsconfig.json
@@ -1,0 +1,22 @@
+{
+  "compilerOptions": {
+    "target": "esnext",
+    "module": "none",
+    "strict": true,
+    "noImplicitAny": true,
+    "noUnusedLocals": true,
+    "noImplicitReturns": true,
+    "moduleResolution": "node",
+    "allowSyntheticDefaultImports": true,     /* Allow default imports from modules with no default export. This does not affect code emit, just typechecking. */
+    "esModuleInterop": true,                  /* Enables emit interoperability between CommonJS and ES Modules via creation of namespace objects for all imports. Implies 'allowSyntheticDefaultImports'. */
+    "experimentalDecorators": true,           /* Enables experimental support for ES7 decorators. */
+
+    "typeRoots": [
+      "./node_modules/@polkadot/ts",
+      "./node_modules/@types"
+    ]
+  },
+  "include": [
+    "src/*.ts"
+  ]
+}


### PR DESCRIPTION
Published the package at https://www.npmjs.com/package/@joystream/types

- [x] Add missing keys in package.json to show better on npmjs
- [x] Add Readme and show example how to use package
