### PR TITLE
It looks like leaving out the `typeRoots` entirely fixes #196

### DIFF
--- a/packages/joy-types/tsconfig.json
+++ b/packages/joy-types/tsconfig.json
@@ -11,12 +11,7 @@
     "esModuleInterop": true,                  /* Enables emit interoperability between CommonJS and ES Modules via creation of namespace objects for all imports. Implies 'allowSyntheticDefaultImports'. */
     "experimentalDecorators": true,           /* Enables experimental support for ES7 decorators. */
     "declaration": true,
-    "outDir": "lib",
-    "typeRoots": [
-      "./node_modules/@polkadot/ts",
-      "./node_modules/@types",
-      "./lib"
-    ]
+    "outDir": "lib"
   },
   "include": [
     "src/*.ts"


### PR DESCRIPTION
It looks like leaving out the `typeRoots` entirely fixes #196
- pioneer still starts and seems possible to navigate
- a linked `joy-types` still builds
- building `joy-types` in its own directory still works

The rationale for `typeRoots` was that prior to yarn workspaces in the
storage node, resolving types was a bit dicey. With workspaces and
typescript's documented behaviour, it seems better for packages to
try to resolve types in the typescript way.

See [@types, typeRoots and
types in the tsconfig.json section](https://www.typescriptlang.org/docs/handbook/tsconfig-json.html)