### PR TITLE
Turns out that I was on the wrong path with regards to fixing #196

### DIFF
--- a/packages/joy-types/src/index.ts
+++ b/packages/joy-types/src/index.ts
@@ -8,11 +8,11 @@ class Amount extends Balance {}
 
 export class OptionText extends Option.with(Text) {
 
-  static none () {
+  static none (): OptionText {
     return new Option(Text, null);
   }
 
-  static some (text: string) {
+  static some (text: string): OptionText {
     return new Option(Text, text);
   }
 }


### PR DESCRIPTION
The typescript error was actually more informative than I expected, and adding type annotations solved the issue. I'd still keep #197, because those `typeRoots` entries are more likely to cause problems than solve them. 