### PR TITLE
Fix restoring sr25519 keys from .json backup

### DIFF
--- a/.yarnclean
+++ b/.yarnclean
@@ -1,0 +1,2 @@
+@types/react-native
+

--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
     "@polkadot/util-crypto": "^0.76.1",
     "babel-core": "^7.0.0-bridge.0",
     "rxjs": "^6.4.0",
-    "typescript": "^3.4.3"
+    "typescript": "^3.4.5"
   },
   "scripts": {
     "analyze": "yarn run build && cd packages/apps && yarn run source-map-explorer build/main.*.js",

--- a/packages/apps/package.json
+++ b/packages/apps/package.json
@@ -14,7 +14,7 @@
   "dependencies": {
     "@babel/runtime": "^7.4.3",
     "@polkadot/ui-app": "^0.32.0-beta.6",
-    "@polkadot/ui-assets": "^0.38.0-beta.2",
+    "@polkadot/ui-assets": "^0.38.0-beta.3",
     "@polkadot/ui-signer": "^0.32.0-beta.6",
     "@types/react-tooltip": "^3.9.1",
     "react-tooltip": "^3.9.2"

--- a/packages/joy-election/package.json
+++ b/packages/joy-election/package.json
@@ -8,7 +8,7 @@
   "maintainers": [],
   "dependencies": {
     "@babel/runtime": "^7.4.3",
-    "@polkadot/ui-app": "^0.31.0-beta.18",
+    "@polkadot/ui-app": "^0.32.0-beta.6",
     "@polkadot/joy-utils": "^0.1.1"
   }
 }

--- a/packages/joy-help/package.json
+++ b/packages/joy-help/package.json
@@ -8,7 +8,7 @@
   "maintainers": [],
   "dependencies": {
     "@babel/runtime": "^7.4.3",
-    "@polkadot/ui-app": "^0.31.0-beta.18",
+    "@polkadot/ui-app": "^0.32.0-beta.6",
     "@polkadot/joy-utils": "^0.1.1"
   }
 }

--- a/packages/joy-media/package.json
+++ b/packages/joy-media/package.json
@@ -8,7 +8,7 @@
   "maintainers": [],
   "dependencies": {
     "@babel/runtime": "^7.4.3",
-    "@polkadot/ui-app": "^0.31.0-beta.18",
+    "@polkadot/ui-app": "^0.32.0-beta.6",
     "@types/mime-types": "^2.1.0",
     "@polkadot/joy-utils": "^0.1.1",
     "aplayer": "^1.10.1",

--- a/packages/joy-members/package.json
+++ b/packages/joy-members/package.json
@@ -8,7 +8,7 @@
   "maintainers": [],
   "dependencies": {
     "@babel/runtime": "^7.4.3",
-    "@polkadot/ui-app": "^0.31.0-beta.18",
+    "@polkadot/ui-app": "^0.32.0-beta.6",
     "@polkadot/joy-utils": "^0.1.1"
   }
 }

--- a/packages/joy-pages/package.json
+++ b/packages/joy-pages/package.json
@@ -8,7 +8,7 @@
   "maintainers": [],
   "dependencies": {
     "@babel/runtime": "^7.4.3",
-    "@polkadot/ui-app": "^0.31.0-beta.18",
+    "@polkadot/ui-app": "^0.32.0-beta.6",
     "@polkadot/joy-utils": "^0.1.1"
   }
 }

--- a/packages/joy-proposals/package.json
+++ b/packages/joy-proposals/package.json
@@ -8,7 +8,7 @@
   "maintainers": [],
   "dependencies": {
     "@babel/runtime": "^7.4.3",
-    "@polkadot/ui-app": "^0.31.0-beta.18",
+    "@polkadot/ui-app": "^0.32.0-beta.6",
     "@polkadot/joy-utils": "^0.1.1"
   }
 }

--- a/packages/joy-roles/package.json
+++ b/packages/joy-roles/package.json
@@ -8,8 +8,8 @@
   "maintainers": [],
   "dependencies": {
     "@babel/runtime": "^7.4.3",
-    "@polkadot/ui-app": "^0.31.0-beta.18",
+    "@polkadot/ui-app": "^0.32.0-beta.6",
     "@polkadot/joy-utils": "^0.1.1",
-    "@polkadot/ui-reactive": "^0.31.0-beta.18"
+    "@polkadot/ui-reactive": "^0.32.0-beta.6"
   }
 }

--- a/packages/joy-types/package.json
+++ b/packages/joy-types/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@joystream/types",
-  "version": "0.1.3",
+  "version": "0.1.8",
   "description": "Joystream types for Substrate modules",
   "main": "lib/index.js",
   "scripts": {
@@ -9,7 +9,7 @@
   "author": "Joystream contributors",
   "maintainers": [],
   "dependencies": {
-    "@polkadot/types": "^0.77.0-beta.4"
+    "@polkadot/types": "=0.77.1"
   },
   "directories": {
     "lib": "lib"

--- a/packages/joy-types/package.json
+++ b/packages/joy-types/package.json
@@ -4,22 +4,19 @@
   "description": "Joystream types for Substrate modules",
   "main": "lib/index.js",
   "scripts": {
-    "postinstall": "npm run build",
     "build": "tsc --build tsconfig.json"
   },
   "author": "Joystream contributors",
   "maintainers": [],
   "dependencies": {
-    "@polkadot/keyring": "^0.76.1",
-    "@polkadot/types": "^0.77.0-beta.4",
-    "@polkadot/util": "^0.76.1",
-    "@polkadot/util-crypto": "^0.76.1",
-    "typescript": "^3.4.5"
+    "@polkadot/types": "^0.77.0-beta.4"
   },
   "directories": {
     "lib": "lib"
   },
-  "devDependencies": {},
+  "devDependencies": {
+    "typescript": "^3.4.5"
+  },
   "repository": {
     "type": "git",
     "url": "git+https://github.com/Joystream/apps.git"

--- a/packages/joy-utils/package.json
+++ b/packages/joy-utils/package.json
@@ -8,7 +8,7 @@
   "maintainers": [],
   "dependencies": {
     "@babel/runtime": "^7.4.3",
-    "@polkadot/ui-app": "^0.31.0-beta.18",
+    "@polkadot/ui-app": "^0.32.0-beta.6",
     "@types/query-string": "^6.2.0",
     "@types/uuid": "^3.4.4",
     "@types/yup": "^0.26.10",

--- a/packages/ui-app/package.json
+++ b/packages/ui-app/package.json
@@ -12,8 +12,8 @@
   "dependencies": {
     "@babel/runtime": "^7.4.3",
     "@polkadot/ui-api": "^0.32.0-beta.6",
-    "@polkadot/ui-identicon": "^0.38.0-beta.2",
-    "@polkadot/ui-keyring": "^0.38.0-beta.2",
+    "@polkadot/ui-identicon": "^0.38.0-beta.3",
+    "@polkadot/ui-keyring": "^0.38.0-beta.3",
     "@polkadot/ui-reactive": "^0.32.0-beta.6",
     "@polkadot/joy-settings": "^1.0.0",
     "@types/chart.js": "^2.7.45",

--- a/yarn.lock
+++ b/yarn.lock
@@ -819,6 +819,13 @@
   dependencies:
     regenerator-runtime "^0.13.2"
 
+"@babel/runtime@^7.4.4":
+  version "7.4.5"
+  resolved "https://registry.yarnpkg.com/@babel/runtime/-/runtime-7.4.5.tgz#582bb531f5f9dc67d2fcb682979894f75e253f12"
+  integrity sha512-TuI4qpWZP6lGOGIuGWtp9sPluqYICmbk8T/1vpSysqJxRPkudh/ofFWyqdcMsDf2s7KvDL4/YHgKyvcS3g9CJQ==
+  dependencies:
+    regenerator-runtime "^0.13.2"
+
 "@babel/template@^7.0.0", "@babel/template@^7.1.0", "@babel/template@^7.2.2", "@babel/template@^7.4.0":
   version "7.4.0"
   resolved "https://registry.yarnpkg.com/@babel/template/-/template-7.4.0.tgz#12474e9c077bae585c5d835a95c0b0b790c25c8b"
@@ -1948,66 +1955,20 @@
     "@polkadot/keyring" "^0.76.1"
     "@polkadot/util" "^0.76.1"
 
-"@polkadot/ui-api@^0.31.1":
-  version "0.31.1"
-  resolved "https://registry.yarnpkg.com/@polkadot/ui-api/-/ui-api-0.31.1.tgz#b3781dec3e732ae15f379a5e68045314417a1987"
-  integrity sha512-htEGca6qx194kifGuHOGNAJ5AOzOLBQY24ZfZbsyNMuMoTLJ4BORmfJcKhx5hIcydVR2U4O5ixxcJrGtjDCHSw==
+"@polkadot/ui-assets@^0.38.0-beta.3":
+  version "0.38.1"
+  resolved "https://registry.yarnpkg.com/@polkadot/ui-assets/-/ui-assets-0.38.1.tgz#493a83e8cfd21e53a2236d30f087c3d73babd6a2"
+  integrity sha512-Oj3yldkpcHFI7A43Prbh34cfUlI8C6ih4nlokjaHsxiSXsi7vYeF+rAns8i4u2oP5QquK6FA/f9hGNigewyoEQ==
   dependencies:
-    "@babel/runtime" "^7.4.3"
-    "@polkadot/api" "^0.77.0-beta.4"
-    rxjs-compat "^6.3.2"
+    "@babel/runtime" "^7.4.4"
 
-"@polkadot/ui-app@^0.31.0-beta.18":
-  version "0.31.1"
-  resolved "https://registry.yarnpkg.com/@polkadot/ui-app/-/ui-app-0.31.1.tgz#8d19480b13fbf82754683e3475ccf0b5b3e1a119"
-  integrity sha512-QTQqIP9t1fLI6MVmV5s+LFCPoFsk5sCthtxOvntD0flpIXz33CEYcCdgEwLVC+Ek9gUEU+qIR4apWIwJhnWyNw==
+"@polkadot/ui-identicon@^0.38.0-beta.3":
+  version "0.38.1"
+  resolved "https://registry.yarnpkg.com/@polkadot/ui-identicon/-/ui-identicon-0.38.1.tgz#2d0883ac145a46b3e635d34c3b6cc632dcad45b4"
+  integrity sha512-B+KbQKS/dAA2U8VfjlEusnnKfHQbUGGjuuFpxZMoH0NXWeuJZFA6Kqmh5HAT9ycVeMtO79r3mTkYUPgqfraPrg==
   dependencies:
-    "@babel/runtime" "^7.4.3"
-    "@polkadot/ui-api" "^0.31.1"
-    "@polkadot/ui-identicon" "^0.38.0-beta.2"
-    "@polkadot/ui-keyring" "^0.38.0-beta.2"
-    "@polkadot/ui-reactive" "^0.31.1"
-    "@polkadot/ui-settings" "^0.38.0-beta.2"
-    "@types/chart.js" "^2.7.45"
-    "@types/classnames" "^2.2.7"
-    "@types/i18next" "^12.1.0"
-    "@types/react-copy-to-clipboard" "^4.2.6"
-    "@types/react-dropzone" "^4.2.2"
-    "@types/react-router-dom" "^4.3.0q"
-    "@types/styled-theming" "^2.2.0"
-    chart.js "^2.7.2"
-    codeflask "^1.4.0"
-    i18next "^15.0.9"
-    i18next-browser-languagedetector "^3.0.1"
-    i18next-xhr-backend "^2.0.1"
-    react "^16.8.2"
-    react-chartjs-2 "^2.7.4"
-    react-copy-to-clipboard "^5.0.1"
-    react-dom "^16.8.2"
-    react-dropzone "^7.0.1"
-    react-i18next "^10.6.0"
-    react-markdown "^4.0.6"
-    react-router "^5.0.0"
-    react-router-dom "^5.0.0"
-    semantic-ui-css "^2.3.1"
-    semantic-ui-react "^0.86.0"
-    store "^2.0.12"
-    styled-theming "^2.2.0"
-
-"@polkadot/ui-assets@^0.38.0-beta.2":
-  version "0.38.0-beta.2"
-  resolved "https://registry.yarnpkg.com/@polkadot/ui-assets/-/ui-assets-0.38.0-beta.2.tgz#dadfd02d7558b9723ba617accedb9fa9ec77f9c3"
-  integrity sha512-b9G+mtAp1ik3b7+Nj7KR9xy+E6CXUZ2O6OhUWez1C3GCpOg6DGKOKJZ1vpZvM4n2+uxua5tVZTb8lbUsaTt4CQ==
-  dependencies:
-    "@babel/runtime" "^7.4.3"
-
-"@polkadot/ui-identicon@^0.38.0-beta.2":
-  version "0.38.0-beta.2"
-  resolved "https://registry.yarnpkg.com/@polkadot/ui-identicon/-/ui-identicon-0.38.0-beta.2.tgz#3a1ac3e7046b83eeddff934b17f94402a7447cbe"
-  integrity sha512-rC8UbqrdngAG+CbpTJxlvSj8+ylzRk0yW2BqvWAckXzJb2DW8odqb3N/qUwRn/EFets4VtmBxeSFWvrUQAR9rQ==
-  dependencies:
-    "@babel/runtime" "^7.4.3"
-    "@polkadot/ui-settings" "^0.38.0-beta.2"
+    "@babel/runtime" "^7.4.4"
+    "@polkadot/ui-settings" "^0.38.1"
     "@types/color" "^3.0.0"
     "@types/react-copy-to-clipboard" "^4.2.6"
     color "^3.0.0"
@@ -2015,32 +1976,22 @@
     react-copy-to-clipboard "^5.0.1"
     styled-components "^4.2.0"
 
-"@polkadot/ui-keyring@^0.38.0-beta.2":
-  version "0.38.0-beta.2"
-  resolved "https://registry.yarnpkg.com/@polkadot/ui-keyring/-/ui-keyring-0.38.0-beta.2.tgz#3ce799dfb6470fb848934bb19223c6ca22b6e397"
-  integrity sha512-HDivNtCaC91CgOSxX3xyENUno7Q4dHj/fwLzWJxQig9bhoxVZM9dsAWv62HwLBFbJE6NfhhMZiogz42Iyw0hgw==
+"@polkadot/ui-keyring@^0.38.0-beta.3":
+  version "0.38.1"
+  resolved "https://registry.yarnpkg.com/@polkadot/ui-keyring/-/ui-keyring-0.38.1.tgz#c9557f010ce217149e164433f9d5a8f61f818b94"
+  integrity sha512-sMQ4sDs8nnvK2i4VICq1oKv1OFzWwfdwk05MBukxgRRajXkOjCfttITzvHuwwq8zcHRRUzWt+Shj96BO97Ufbw==
   dependencies:
-    "@babel/runtime" "^7.4.3"
+    "@babel/runtime" "^7.4.4"
     "@types/store" "^2.0.1"
-    rxjs "^6.4.0"
     store "^2.0.12"
     styled-components "^4.2.0"
 
-"@polkadot/ui-reactive@^0.31.0-beta.18", "@polkadot/ui-reactive@^0.31.1":
-  version "0.31.1"
-  resolved "https://registry.yarnpkg.com/@polkadot/ui-reactive/-/ui-reactive-0.31.1.tgz#a653a28cb51d6fe2b5754dd5b61073519256ab20"
-  integrity sha512-exViFmEOIkCN0yOUfGSlAr6MBBH1R8S9DQ3xWurnKgnvAzYF1t0ID4diQwmHAmygBQucWI7nPvkJInkrPypxrw==
+"@polkadot/ui-settings@^0.38.1":
+  version "0.38.1"
+  resolved "https://registry.yarnpkg.com/@polkadot/ui-settings/-/ui-settings-0.38.1.tgz#c52ede839a8b04b20b1177131087c96d64f1edb6"
+  integrity sha512-ZpqCcusimDMrkqqcYS+49OuTcmO9RsjrUq6J2+B74vnABJaRQ702YUJJtHPvmehF30fRFIxm3yeBp97y+EPb4w==
   dependencies:
-    "@babel/runtime" "^7.4.3"
-    rxjs-compat "^6.3.2"
-
-"@polkadot/ui-settings@^0.38.0-beta.2":
-  version "0.38.0-beta.2"
-  resolved "https://registry.yarnpkg.com/@polkadot/ui-settings/-/ui-settings-0.38.0-beta.2.tgz#dec7457ebf1dff5cf304a361cb487f37b90d5a2f"
-  integrity sha512-ouRaNB4qWOqd088zemNN3bukYNna7jlCpvL/dRO/N5nBfIxwxmMCjtD5gvKMeJWZf9zkE82jOzJeFrgzEudfag==
-  dependencies:
-    "@babel/runtime" "^7.4.3"
-    "@polkadot/util" "^0.76.1"
+    "@babel/runtime" "^7.4.4"
     "@types/store" "^2.0.1"
     store "^2.0.12"
 
@@ -14618,10 +14569,10 @@ typedoc@^0.14.2:
     typedoc-default-themes "^0.5.0"
     typescript "3.2.x"
 
-typescript@3.2.x, typescript@^3.4.3:
-  version "3.4.3"
-  resolved "https://registry.yarnpkg.com/typescript/-/typescript-3.4.3.tgz#0eb320e4ace9b10eadf5bc6103286b0f8b7c224f"
-  integrity sha512-FFgHdPt4T/duxx6Ndf7hwgMZZjZpB+U0nMNGVCYPq0rEzWKjEDobm4J6yb3CS7naZ0yURFqdw9Gwc7UOh/P9oQ==
+typescript@3.2.x, typescript@^3.4.3, typescript@^3.4.5:
+  version "3.4.5"
+  resolved "https://registry.yarnpkg.com/typescript/-/typescript-3.4.5.tgz#2d2618d10bb566572b8d7aad5180d84257d70a99"
+  integrity sha512-YycBxUb49UUhdNMU5aJ7z5Ej2XGmaIBL0x34vZ82fn3hGvD+bgrMrVDpatgz2f7YxUMJxMkbWxJZeAvDxVe7Vw==
 
 ua-parser-js@^0.7.18:
   version "0.7.19"


### PR DESCRIPTION
Fixes #131 and #150 

In initial fix attempt #140, two versions of ui-keyring were indeed being loaded separately because the joy-* modules didn't correctly depend on the local ui-apps package.

While running yarn build also came across a bunch of build issues for @joystream/types (related to running tsc in postinsall script), and issue related to typescript:

```
../node_modules/@types/react-native/globals.d.ts:36:15 - error TS2300: Duplicate identifier 'FormData'.

36 declare class FormData {
                 ~~~~~~~~

  ../node_modules/typescript/lib/lib.dom.d.ts:5292:11
    5292 interface FormData {
                   ~~~~~~~~
    'FormData' was also declared here.
  ../node_modules/typescript/lib/lib.dom.d.ts:5302:13
    5302 declare var FormData: {
                     ~~~~~~~~
    and here.
  ../node_modules/typescript/lib/lib.dom.iterable.d.ts:67:11
    67 interface FormData {
                 ~~~~~~~~
    and here.
```

Found suggested solution in [related issue](https://github.com/DefinitelyTyped/DefinitelyTyped/issues/33015) by adding a `.yarnclean` as in [this pr](https://github.com/sinnerschrader/feature-hub/pull/484)
