### PR TITLE
media: improved upload ux

### DIFF
--- a/packages/joy-media/src/Upload.tsx
+++ b/packages/joy-media/src/Upload.tsx
@@ -271,7 +271,7 @@ class Component extends React.PureComponent<Props, State> {
 
     // TODO: validate url .. must start with http
 
-    this.setState({ discovering: false, progress: 0, uploading: true });
+    this.setState({ discovering: false, uploading: true, progress: 0 });
 
     try {
       await axios.put<{ message: string }>(url, file, config);

--- a/packages/joy-media/src/Upload.tsx
+++ b/packages/joy-media/src/Upload.tsx
@@ -104,7 +104,7 @@ class Component extends React.PureComponent<Props, State> {
 
     return <div style={{ width: '100%' }}>
       {this.renderProgress()}
-      { success ? <EditMeta contentId={newContentId} fileName={fileNameWoExt(file.name)} /> : null }
+      {success && <EditMeta contentId={newContentId} fileName={fileNameWoExt(file.name)} />}
     </div>;
   }
 


### PR DESCRIPTION
If upload fails, either due to liaison being unreachable, or iterruption during upload, we don't want to content meta data to be added. So the edit form will only appear after successful upload. (We should probably also have pioneer wait for liaison judgement in future)