### PR TITLE
update joy-types to support new modules

### DIFF
--- a/packages/joy-types/src/content-working-group/index.ts
+++ b/packages/joy-types/src/content-working-group/index.ts
@@ -319,6 +319,17 @@ export class Lead extends JoyStruct<ILead> {
   }
 };
 
+export class WorkingGroupUnstaker extends Enum {
+  constructor (value?: any, index?: number) {
+    super(
+      {
+        Lead: LeadId,
+        Curator: CuratorId,
+      },
+      value, index);
+  }
+}
+
 export function registerContentWorkingGroupTypes () {
     try {
       getTypeRegistry().register({
@@ -339,7 +350,7 @@ export function registerContentWorkingGroupTypes () {
         Lead,
         OpeningPolicyCommitment,
         Principal,
-        WorkingGroupUnstaker: {},
+        WorkingGroupUnstaker,
       });
     } catch (err) {
       console.error('Failed to register custom types of content working group module', err);

--- a/packages/joy-types/src/content-working-group/index.ts
+++ b/packages/joy-types/src/content-working-group/index.ts
@@ -1,0 +1,39 @@
+import { getTypeRegistry } from '@polkadot/types';
+import { ActorId } from '../members';
+import { OpeningId, ApplicationId } from '../hiring';
+import { Credential } from '../versioned-store/permissions/credentials';
+
+export class ChannelId extends ActorId {};
+export class CuratorId extends ActorId {};
+export class CuratorOpeningId extends OpeningId {};
+export class CuratorApplicationId extends ApplicationId {};
+export class LeadId extends ActorId {};
+export class PrincipalId extends Credential {};
+
+export function registerContentWorkingGroupTypes () {
+    try {
+      getTypeRegistry().register({
+        ChannelId,
+        CuratorId,
+        CuratorOpeningId,
+        CuratorApplicationId,
+        LeadId,
+        PrincipalId,
+        // todo
+        'Channel': {},
+        'ChannelContentType': {},
+        'ChannelCurationStatus': {},
+        'ChannelPublishingStatus': {},
+        'CurationActor': {},
+        'Curator': {},
+        'CuratorApplication': {},
+        'CuratorOpening': {},
+        'Lead': {},
+        'OpeningPolicyCommitment': {},
+        'Principal': {},
+        'WorkingGroupUnstaker': {},
+      });
+    } catch (err) {
+      console.error('Failed to register custom types of content working group module', err);
+    }
+}

--- a/packages/joy-types/src/content-working-group/index.ts
+++ b/packages/joy-types/src/content-working-group/index.ts
@@ -1,7 +1,12 @@
-import { getTypeRegistry } from '@polkadot/types';
-import { ActorId } from '../members';
-import { OpeningId, ApplicationId } from '../hiring';
+import { getTypeRegistry, Enum, bool, u8, u32, Text, GenericAccountId, Null , Option, Vec, u16 } from '@polkadot/types';
+import { BlockNumber, AccountId } from '@polkadot/types/interfaces';
+import { ActorId, MemberId } from '../members';
+import { OpeningId, ApplicationId, ApplicationRationingPolicy, StakingPolicy } from '../hiring';
 import { Credential } from '../versioned-store/permissions/credentials';
+import { RewardRelationshipId } from '../recurring-rewards';
+import { StakeId } from '../stake';
+import { JoyStruct } from '../JoyStruct';
+import { BTreeSet } from '../';
 
 export class ChannelId extends ActorId {};
 export class CuratorId extends ActorId {};
@@ -9,6 +14,310 @@ export class CuratorOpeningId extends OpeningId {};
 export class CuratorApplicationId extends ApplicationId {};
 export class LeadId extends ActorId {};
 export class PrincipalId extends Credential {};
+
+export class ChannelContentType extends Enum {
+  constructor (value?: any, index?: number) {
+    super(
+      [
+        'Video',
+        'Music',
+        'Ebook',
+      ],
+      value, index);
+  }
+};
+
+export class ChannelPublishingStatus extends Enum {
+  constructor (value?: any, index?: number) {
+    super(
+      [
+        'Published',
+        'NotPunblished',
+      ],
+      value, index);
+  }
+};
+
+export class ChannelCurationStatus extends Enum {
+  constructor (value?: any, index?: number) {
+    super(
+      [
+        'Normal',
+        'Censored',
+      ],
+      value, index);
+  }
+};
+
+export type IChannel = {
+  channel_name: Text, // Vec<u8>,
+  verified: bool,
+  description: Text, // Vec<u8>,
+  content: ChannelContentType,
+  owner: MemberId,
+  role_account: AccountId,
+  publishing_status: ChannelPublishingStatus,
+  curation_status: ChannelCurationStatus,
+  created: BlockNumber,
+  principal_id: PrincipalId,
+};
+export class Channel extends JoyStruct<IChannel> {
+  constructor (value?: IChannel) {
+    super({
+      channel_name: Text, // Vec.with(u8),
+      verified: bool,
+      description: Text, // Vec.with(u8),
+      content: ChannelContentType,
+      owner: MemberId,
+      role_account: GenericAccountId,
+      publishing_status: ChannelPublishingStatus,
+      curation_status: ChannelCurationStatus,
+      created: u32, // BlockNumber,
+      principal_id: PrincipalId,
+    }, value);
+  }
+};
+
+export class CurationActor extends Enum {
+  constructor (value?: any, index?: number) {
+    super(
+      {
+        Lead: Null,
+        Curator: CuratorId
+      },
+      value, index);
+  }
+};
+
+export class Principal extends Enum {
+  constructor (value?: any, index?: number) {
+    super(
+      {
+        Lead: Null,
+        Curator: CuratorId,
+        ChannelOwner: ChannelId
+      },
+      value, index);
+  }
+};
+
+export type ICuratorRoleStakeProfile = {
+  stake_id: StakeId,
+  termination_unstaking_period: Option<BlockNumber>,
+  exit_unstaking_period: Option<BlockNumber>,
+};
+export class CuratorRoleStakeProfile extends JoyStruct<ICuratorRoleStakeProfile> {
+  constructor (value?: ICuratorRoleStakeProfile) {
+    super({
+      stake_id: StakeId,
+      termination_unstaking_period: Option.with(u32),
+      exit_unstaking_period: Option.with(u32),
+    }, value);
+  }
+};
+
+export class CuratorExitInitiationOrigin extends Enum {
+  constructor (value?: any, index?: number) {
+    super(
+      {
+        Lead: Null,
+        Curator: Null,
+      },
+      value, index);
+  }
+}
+
+export type ICuratorExitSummary = {
+  origin: CuratorExitInitiationOrigin,
+  initiated_at_block_number: BlockNumber,
+  rationale_text: Vec<u8>,
+};
+export class CuratorExitSummary extends JoyStruct<ICuratorExitSummary> {
+  constructor (value?: ICuratorExitSummary) {
+    super({
+      origin: CuratorExitInitiationOrigin,
+      initiated_at_block_number: u32,
+      rationale_text: Text,
+    }, value);
+  }
+};
+
+export class CuratorRoleStage extends Enum {
+  constructor (value?: any, index?: number) {
+    super(
+      {
+        Active: Null,
+        Unstaking: CuratorExitSummary,
+        Exited: CuratorExitSummary
+      },
+      value, index);
+  }
+};
+
+export type ICuratorInduction = {
+  lead: LeadId,
+  curator_application_id: CuratorApplicationId,
+  at_block: BlockNumber,
+};
+export class CuratorInduction extends JoyStruct<ICuratorInduction> {
+  constructor (value?: ICuratorInduction) {
+    super({
+      lead: LeadId,
+      curator_application_id: CuratorApplicationId,
+      at_block: u32,
+    }, value);
+  }
+};
+
+export type ICurator = {
+  role_account: AccountId,
+  reward_relationship: Option<RewardRelationshipId>,
+  role_stake_profile: Option<CuratorRoleStakeProfile>,
+  stage: CuratorRoleStage,
+  induction: CuratorInduction,
+  principal_id: PrincipalId,
+};
+export class Curator extends JoyStruct<ICurator> {
+  constructor (value?: ICurator) {
+    super({
+      role_account: GenericAccountId,
+      reward_relationship: Option.with(RewardRelationshipId),
+      role_stake_profile: Option.with(CuratorRoleStakeProfile),
+      stage: CuratorRoleStage,
+      induction: CuratorInduction,
+      principal_id: PrincipalId,
+    }, value);
+  }
+};
+
+export type ICuratorApplication = {
+  role_account: AccountId,
+  curator_opening_id: CuratorOpeningId,
+  member_id: MemberId,
+  application_id: ApplicationId,
+};
+export class CuratorApplication extends JoyStruct<ICuratorApplication> {
+  constructor (value?: ICuratorApplication) {
+    super({
+      role_account: GenericAccountId,
+      curator_opening_id: CuratorOpeningId,
+      member_id: MemberId,
+      application_id: ApplicationId,
+    }, value);
+  }
+};
+
+
+export type ISlashableTerms = {
+    max_count: u16,
+    max_percent_pts_per_time: u16,
+};
+export class SlashableTerms extends JoyStruct<ISlashableTerms> {
+  constructor (value?: ISlashableTerms) {
+    super({
+      max_count: u16,
+      max_percent_pts_per_time: u16,
+    }, value);
+  }
+};
+
+export class SlashingTerms extends Enum {
+  constructor (value?: any, index?: number) {
+    super(
+      {
+        Unslashable: Null,
+        Slashable: SlashableTerms,
+      },
+      value, index);
+  }
+};
+
+export type IOpeningPolicyCommitment = {
+  application_rationing_policy: Option<ApplicationRationingPolicy>,
+  max_review_period_length: BlockNumber,
+  application_staking_policy: Option<StakingPolicy>,
+  role_staking_policy: Option<StakingPolicy>,
+  role_slashing_terms: SlashingTerms,
+  fill_opening_successful_applicant_application_stake_unstaking_period: Option<BlockNumber>,
+  fill_opening_failed_applicant_application_stake_unstaking_period: Option<BlockNumber>,
+  fill_opening_failed_applicant_role_stake_unstaking_period: Option<BlockNumber>,
+  terminate_curator_application_stake_unstaking_period: Option<BlockNumber>,
+  terminate_curator_role_stake_unstaking_period: Option<BlockNumber>,
+  exit_curator_role_application_stake_unstaking_period: Option<BlockNumber>,
+  exit_curator_role_stake_unstaking_period: Option<BlockNumber>,
+};
+export class OpeningPolicyCommitment extends JoyStruct<IOpeningPolicyCommitment> {
+  constructor (value?: IOpeningPolicyCommitment) {
+    super({
+      application_rationing_policy: Option.with(ApplicationRationingPolicy),
+      max_review_period_length: u32, // BlockNumber,
+      application_staking_policy: Option.with(StakingPolicy),
+      role_staking_policy: Option.with(StakingPolicy),
+      role_slashing_terms: SlashingTerms,
+      fill_opening_successful_applicant_application_stake_unstaking_period: Option.with(u32),
+      fill_opening_failed_applicant_application_stake_unstaking_period: Option.with(u32),
+      fill_opening_failed_applicant_role_stake_unstaking_period: Option.with(u32),
+      terminate_curator_application_stake_unstaking_period: Option.with(u32),
+      terminate_curator_role_stake_unstaking_period: Option.with(u32),
+      exit_curator_role_application_stake_unstaking_period: Option.with(u32),
+      exit_curator_role_stake_unstaking_period: Option.with(u32),
+    }, value);
+  }
+};
+
+export type ICuratorOpening = {
+  opening_id: OpeningId,
+  curator_applications: BTreeSet<CuratorApplicationId>,
+  policy_commitment: OpeningPolicyCommitment,
+};
+export class CuratorOpening extends JoyStruct<ICuratorOpening> {
+  constructor (value?: ICuratorOpening) {
+    super({
+      opening_id: OpeningId,
+      curator_applications: BTreeSet.with(CuratorApplicationId),
+      policy_commitment: OpeningPolicyCommitment,
+    }, value);
+  }
+};
+
+export type IExitedLeadRole = {
+  initiated_at_block_number: BlockNumber,
+};
+export class ExitedLeadRole extends JoyStruct<IExitedLeadRole> {
+  constructor (value?: IExitedLeadRole) {
+    super({
+      initiated_at_block_number: u32,
+    }, value);
+  }
+};
+
+export class LeadRoleState extends Enum {
+  constructor (value?: any, index?: number) {
+    super(
+      {
+        Active: Null,
+        Exited: ExitedLeadRole,
+      },
+      value, index);
+  }
+}
+
+export type ILead = {
+  role_account: AccountId,
+  reward_relationship: Option<RewardRelationshipId>,
+  inducted: BlockNumber,
+  stage: LeadRoleState,
+};
+export class Lead extends JoyStruct<ILead> {
+  constructor (value?: ILead) {
+    super({
+      role_account: GenericAccountId,
+      reward_relationship: Option.with(RewardRelationshipId),
+      inducted: u32,
+      stage: LeadRoleState,
+    }, value);
+  }
+};
 
 export function registerContentWorkingGroupTypes () {
     try {
@@ -19,19 +328,18 @@ export function registerContentWorkingGroupTypes () {
         CuratorApplicationId,
         LeadId,
         PrincipalId,
-        // todo
-        'Channel': {},
-        'ChannelContentType': {},
-        'ChannelCurationStatus': {},
-        'ChannelPublishingStatus': {},
-        'CurationActor': {},
-        'Curator': {},
-        'CuratorApplication': {},
-        'CuratorOpening': {},
-        'Lead': {},
-        'OpeningPolicyCommitment': {},
-        'Principal': {},
-        'WorkingGroupUnstaker': {},
+        Channel,
+        ChannelContentType,
+        ChannelCurationStatus,
+        ChannelPublishingStatus,
+        CurationActor,
+        Curator,
+        CuratorApplication,
+        CuratorOpening,
+        Lead,
+        OpeningPolicyCommitment,
+        Principal,
+        WorkingGroupUnstaker: {},
       });
     } catch (err) {
       console.error('Failed to register custom types of content working group module', err);

--- a/packages/joy-types/src/content-working-group/index.ts
+++ b/packages/joy-types/src/content-working-group/index.ts
@@ -265,6 +265,7 @@ export class OpeningPolicyCommitment extends JoyStruct<IOpeningPolicyCommitment>
   }
 };
 
+// Not entierly sure that using BTreeSet will work correctly when reading/decoding this type from chain state
 export type ICuratorOpening = {
   opening_id: OpeningId,
   curator_applications: BTreeSet<CuratorApplicationId>,

--- a/packages/joy-types/src/hiring/index.ts
+++ b/packages/joy-types/src/hiring/index.ts
@@ -1,5 +1,5 @@
-import { getTypeRegistry, Null, u128, u64, u32, u8, Vec, Option } from '@polkadot/types';
-import { Enum, /* BTreeSet, */ } from '@polkadot/types/codec';
+import { getTypeRegistry, Null, u128, u64, u32, Vec, Option, Text } from '@polkadot/types';
+import { Enum } from '@polkadot/types/codec';
 import { BlockNumber, Balance } from '@polkadot/types/interfaces';
 import { JoyStruct } from '../JoyStruct';
 
@@ -164,7 +164,7 @@ export class ActiveOpeningStage extends Enum {
             'Deactivated': Deactivated,
           },
           value, index);
-      }
+    }
 }
 
 export type ActiveOpeningStageVariantType = {
@@ -232,7 +232,7 @@ export type IOpening = {
     application_rationing_policy: Option<ApplicationRationingPolicy>,
     application_staking_policy: Option<StakingPolicy>,
     role_staking_policy: Option<StakingPolicy>,
-    human_readable_text: Vec<u8>,
+    human_readable_text: Text, // Vec<u8>,
 };
 
 export class Opening extends JoyStruct<IOpening> {
@@ -244,7 +244,7 @@ export class Opening extends JoyStruct<IOpening> {
         application_rationing_policy: Option.with(ApplicationRationingPolicy),
         application_staking_policy: Option.with(StakingPolicy),
         role_staking_policy: Option.with(StakingPolicy),
-        human_readable_text: Vec.with(u8),
+        human_readable_text: Text, // Vec.with(u8),
       }, value);
     }
 };

--- a/packages/joy-types/src/hiring/index.ts
+++ b/packages/joy-types/src/hiring/index.ts
@@ -1,0 +1,278 @@
+import { getTypeRegistry, Null, u128, u64, u32, u8, Vec, Option } from '@polkadot/types';
+import { Enum, /* BTreeSet, */ } from '@polkadot/types/codec';
+import { BlockNumber, Balance } from '@polkadot/types/interfaces';
+import { JoyStruct } from '../JoyStruct';
+
+export class ApplicationId extends u64 {};
+export class OpeningId extends u64 {};
+
+export class CurrentBlock extends Null {};
+export class ExactBlock extends u32 {}; // BlockNumber
+
+export class ActivateOpeningAt extends Enum {
+    constructor (value?: any, index?: number) {
+        super(
+          {
+            CurrentBlock,
+            ExactBlock,
+          },
+          value, index);
+      }
+}
+
+export class ApplicationDeactivationCause extends Enum {
+    constructor (value?: any, index?: number) {
+        super(
+          [
+            'External',
+            'Hired',
+            'NotHired',
+            'CrowdedOut',
+            'OpeningCancelled',
+            'ReviewPeriodExpired',
+            'OpeningFilled',
+          ],
+          value, index);
+    }
+};
+
+export type UnstakingApplicationStageType = {
+    deactivation_initiated: BlockNumber,
+    case: ApplicationDeactivationCause
+};
+export class UnstakingApplicationStage extends JoyStruct<UnstakingApplicationStageType> {
+    constructor (value?: UnstakingApplicationStageType) {
+      super({
+        deactivation_initiated: u32, // BlockNumber
+        cause: ApplicationDeactivationCause,
+      }, value);
+    }
+};
+
+export type InactiveApplicationStageType = {
+    deactivation_initiated: BlockNumber,
+    deactivated: BlockNumber,
+    case: ApplicationDeactivationCause
+};
+export class InactiveApplicationStage extends JoyStruct<InactiveApplicationStageType> {
+    constructor (value?: InactiveApplicationStageType) {
+      super({
+        deactivation_initiated: u32, // BlockNumber
+        deactivated: u32,
+        cause: ApplicationDeactivationCause,
+      }, value);
+    }
+};
+
+export class ActiveApplicationStage extends Null {};
+
+export class ApplicationStage extends Enum {
+    constructor (value?: any, index?: number) {
+      super(
+        {
+          'Active': Null,
+          'Unstaking': UnstakingApplicationStage,
+          'Inactive': InactiveApplicationStage,
+        },
+        value, index);
+    }
+}
+
+export type IApplicationRationingPolicy = {
+    max_active_applicants: u32,
+};
+export class ApplicationRationingPolicy extends JoyStruct<IApplicationRationingPolicy> {
+    constructor (value?: IApplicationRationingPolicy) {
+        super({
+            max_active_applicants: u32,
+        }, value);
+    }
+};
+
+export type WaitingToBeingOpeningStageVariantType = {
+    begins_at_block: BlockNumber,
+};
+export class WaitingToBeingOpeningStageVariant extends JoyStruct<WaitingToBeingOpeningStageVariantType> {
+    constructor (value?: WaitingToBeingOpeningStageVariantType) {
+        super({
+            begins_at_block: u32,
+        }, value);
+    }
+};
+
+export class OpeningDeactivationCause extends Enum {
+    constructor (value?: any, index?: number) {
+        super(
+          [
+            'CancelledBeforeActivation',
+            'CancelledAcceptingApplications',
+            'CancelledInReviewPeriod',
+            'ReviewPeriodExpired',
+            'Filled',
+          ],
+          value, index);
+    }
+};
+
+export type IAcceptingApplications = {
+    started_accepting_applicants_at_block: BlockNumber,
+};
+export class AcceptingApplications extends JoyStruct<IAcceptingApplications> {
+    constructor (value?: IAcceptingApplications) {
+        super({
+            started_accepting_applicants_at_block: u32,
+        }, value);
+    }
+};
+
+export type IReviewPeriod = {
+    started_accepting_applicants_at_block: BlockNumber,
+    started_review_period_at_block: BlockNumber,
+};
+export class ReviewPeriod extends JoyStruct<IReviewPeriod> {
+    constructor (value?: IReviewPeriod) {
+        super({
+            started_accepting_applicants_at_block: u32,
+            started_review_period_at_block: u32,
+        }, value);
+    }
+};
+
+export type IDeactivated = {
+    cause: OpeningDeactivationCause,
+    deactivated_at_block: BlockNumber,
+    started_accepting_applicants_at_block: BlockNumber,
+    started_review_period_at_block: Option<BlockNumber>,
+};
+export class Deactivated extends JoyStruct<IDeactivated> {
+    constructor (value?: IDeactivated) {
+        super({
+            cause: OpeningDeactivationCause,
+            deactivated_at_block: u32,
+            started_accepting_applicants_at_block: u32,
+            started_review_period_at_block: Option.with(u32),
+        }, value);
+    }
+};
+
+export class ActiveOpeningStage extends Enum {
+    constructor (value?: any, index?: number) {
+        super(
+          {
+            'AcceptingApplications': AcceptingApplications,
+            'ReviewPeriod': ReviewPeriod,
+            'Deactivated': Deactivated,
+          },
+          value, index);
+      }
+}
+
+export type ActiveOpeningStageVariantType = {
+    stage: ActiveOpeningStage,
+    applications_added: Vec<ApplicationId>,//BTreeSet<ApplicationId>,
+    active_application_count: u32,
+    unstaking_application_count: u32,
+    deactivated_application_count: u32,
+}
+export class ActiveOpeningStageVariant extends JoyStruct<ActiveOpeningStageVariantType> {
+    constructor (value?: ActiveOpeningStageVariantType) {
+        super({
+            stage: ActiveOpeningStage,
+            applications_added: Vec.with(ApplicationId),//BTreeSet<ApplicationId>,
+            active_application_count: u32,
+            unstaking_application_count: u32,
+            deactivated_application_count: u32,
+        }, value);
+    }
+}
+
+export class OpeningStage extends Enum {
+    constructor (value?: any, index?: number) {
+        super(
+          {
+            'WaitingToBegin': WaitingToBeingOpeningStageVariant,
+            'Active': ActiveOpeningStageVariant,
+          },
+          value, index);
+    }
+};
+
+export class StakingAmountLimitMode extends Enum {
+    constructor (value?: any, index?: number) {
+        super(
+          [
+            'AtLeast',
+            'Exact',
+          ],
+          value, index);
+    }
+};
+
+export type IStakingPolicy = {
+    amount: Balance,
+    amount_mode: StakingAmountLimitMode,
+    crowded_out_unstaking_period_length: Option<BlockNumber>,
+    review_period_expired_unstaking_period_length: Option<BlockNumber>,
+};
+export class StakingPolicy extends JoyStruct<IStakingPolicy> {
+    constructor (value?: IStakingPolicy) {
+        super({
+            amount: u128,
+            amount_mode: StakingAmountLimitMode,
+            crowded_out_unstaking_period_length: Option.with(u32),
+            review_period_expired_unstaking_period_length: Option.with(u32),
+        }, value);
+    }
+};
+
+export type IOpening = {
+    created: BlockNumber,
+    stage: OpeningStage,
+    max_review_period_length: BlockNumber,
+    application_rationing_policy: Option<ApplicationRationingPolicy>,
+    application_staking_policy: Option<StakingPolicy>,
+    role_staking_policy: Option<StakingPolicy>,
+    human_readable_text: Vec<u8>,
+};
+
+export class Opening extends JoyStruct<IOpening> {
+    constructor (value?: IOpening) {
+      super({
+        created: u32,
+        stage: OpeningStage,
+        max_review_period_length: u32,
+        application_rationing_policy: Option.with(ApplicationRationingPolicy),
+        application_staking_policy: Option.with(StakingPolicy),
+        role_staking_policy: Option.with(StakingPolicy),
+        human_readable_text: Vec.with(u8),
+      }, value);
+    }
+};
+
+export function registerHiringTypes () {
+    try {
+      getTypeRegistry().register({
+        ApplicationId,
+        OpeningId,
+        // Make into a ts type
+        Application: {
+            opening_id: 'OpeningId',
+            application_index_in_opening: 'u32',
+            add_to_opening_in_block: 'BlockNumber',
+            active_role_staking_id: 'Option<StakeId>',
+            active_application_staking_id: 'Option<StakeId>',
+            stage: 'ApplicationStage',
+            human_readable_text: 'Text'
+        },
+        ApplicationStage,
+        // why the prefix? is there some other identically named type?
+        'hiring::ActivateOpeningAt': ActivateOpeningAt,
+        ApplicationRationingPolicy,
+        OpeningStage,
+        StakingPolicy,
+        Opening,
+      });
+    } catch (err) {
+      console.error('Failed to register custom types of hiring module', err);
+    }
+  }

--- a/packages/joy-types/src/index.ts
+++ b/packages/joy-types/src/index.ts
@@ -1,4 +1,4 @@
-import { Enum, Option, Struct } from '@polkadot/types/codec';
+import { Enum, Option, Struct, Vec } from '@polkadot/types/codec';
 import { getTypeRegistry, Text } from '@polkadot/types';
 import { BlockNumber, AccountId, Balance, Hash } from '@polkadot/types/interfaces';
 import { u32, bool } from '@polkadot/types/primitive';
@@ -11,6 +11,11 @@ import { registerRolesTypes } from './roles';
 import { registerDiscoveryTypes } from './discovery';
 import { registerVersionedStoreTypes } from './versioned-store';
 import { registerVersionedStorePermissionsTypes } from './versioned-store/permissions';
+import { registerStakeTypes } from './stake';
+import { registerHiringTypes } from './hiring';
+import { registerMintTypes } from './mint';
+import { registerRecurringRewardsTypes } from './recurring-rewards';
+import { registerContentWorkingGroupTypes } from './content-working-group';
 
 export function getTextPropAsString (struct: Struct, fieldName: string): string {
   return (struct.get(fieldName) as Text).toString();
@@ -173,10 +178,18 @@ export class VoteKind extends Enum {
 
 export type ProposalVotes = [AccountId, VoteKind][];
 
+// Treat a BTreeSet as a Vec since it is encoded in the same way.
+export class BTreeSet<T extends Codec> extends Vec<T> {};
+
 // TODO Refactor: split this function and move to corresponding modules: election and proposals.
 function registerElectionAndProposalTypes () {
   try {
     const typeRegistry = getTypeRegistry();
+    // Is this enough?
+    typeRegistry.register({
+      BTreeSet
+    });
+
     typeRegistry.register({
       MemoText: 'Text'
     });
@@ -189,7 +202,7 @@ function registerElectionAndProposalTypes () {
       VoteKind
     });
     typeRegistry.register({
-      'Stake': {
+      'ElectionStake': {
         'new': 'Balance',
         'transferred': 'Balance'
       },
@@ -206,7 +219,7 @@ function registerElectionAndProposalTypes () {
       'SealedVote': {
         'voter': 'AccountId',
         'commitment': 'Hash',
-        'stake': 'Stake',
+        'stake': 'ElectionStake',
         'vote': 'Option<AccountId>'
       },
       'TransferableStake': {
@@ -247,4 +260,9 @@ export function registerJoystreamTypes () {
   registerDiscoveryTypes();
   registerVersionedStoreTypes();
   registerVersionedStorePermissionsTypes();
+  registerStakeTypes();
+  registerHiringTypes();
+  registerMintTypes();
+  registerRecurringRewardsTypes();
+  registerContentWorkingGroupTypes();
 }

--- a/packages/joy-types/src/members.ts
+++ b/packages/joy-types/src/members.ts
@@ -2,7 +2,6 @@ import { Enum, getTypeRegistry, Option, Struct, Null, bool, u64, u128, Text, Gen
 import { BlockNumber, Moment, BalanceOf } from '@polkadot/types/interfaces';
 import { OptionText } from './index';
 import AccountId from '@polkadot/types/primitive/Generic/AccountId';
-import { JoyStruct } from './JoyStruct';
 
 export class MemberId extends u64 {}
 export class PaidTermId extends u64 {}

--- a/packages/joy-types/src/members.ts
+++ b/packages/joy-types/src/members.ts
@@ -107,7 +107,7 @@ export function registerMembershipTypes () {
         subscription: 'Option<SubscriptionId>',
         root_account: 'AccountId',
         controller_account: 'AccountId',
-        roles: 'BTreeSet<ActorInRole>' // BTreeSet<ActorInRole>
+        roles: 'Vec<ActorInRole>' // BTreeSet<ActorInRole>
       },
       UserInfo,
       CheckedUserInfo: {

--- a/packages/joy-types/src/members.ts
+++ b/packages/joy-types/src/members.ts
@@ -6,6 +6,7 @@ import AccountId from '@polkadot/types/primitive/Generic/AccountId';
 export class MemberId extends u64 {}
 export class PaidTermId extends u64 {}
 export class SubscriptionId extends u64 {}
+export class ActorId extends u64 {}
 
 export class Paid extends PaidTermId {}
 export class Screening extends GenericAccountId {}
@@ -24,7 +25,7 @@ export class Role extends Enum {
   constructor (value?: any, index?: number) {
     super([
       'StorageProvider',
-      'Publisher',
+      'ChannelOwner',
       'CuratorLead',
       'Curator',
     ], value, index);
@@ -110,7 +111,7 @@ export function registerMembershipTypes () {
         text: 'Text'
       },
       Role,
-      ActorId: 'u64',
+      ActorId,
       ActorInRole: {
         role: 'Role',
         actor_id: 'ActorId'

--- a/packages/joy-types/src/members.ts
+++ b/packages/joy-types/src/members.ts
@@ -1,7 +1,8 @@
-import { Enum, getTypeRegistry, Option, Struct, Null, bool, u64, u128, Text, GenericAccountId } from '@polkadot/types';
+import { Enum, getTypeRegistry, Option, Struct, Null, bool, u64, u128, Text, GenericAccountId, Vec } from '@polkadot/types';
 import { BlockNumber, Moment, BalanceOf } from '@polkadot/types/interfaces';
 import { OptionText } from './index';
 import AccountId from '@polkadot/types/primitive/Generic/AccountId';
+import { JoyStruct } from './JoyStruct';
 
 export class MemberId extends u64 {}
 export class PaidTermId extends u64 {}
@@ -43,7 +44,16 @@ export type Profile = {
   subscription: Option<SubscriptionId>,
   root_account: AccountId,
   controller_account: AccountId,
-  // roles: Vec<ActorInRole>,
+  roles: Vec<ActorInRole>,
+};
+
+export class ActorInRole extends Struct {
+  constructor (value?: any) {
+    super({
+      role: Role,
+      actor_id: ActorId,
+    }, value);
+  }
 };
 
 export class UserInfo extends Struct {
@@ -98,7 +108,7 @@ export function registerMembershipTypes () {
         subscription: 'Option<SubscriptionId>',
         root_account: 'AccountId',
         controller_account: 'AccountId',
-        roles: 'Vec<ActorInRole>' // BTreeSet<ActorInRole>
+        roles: 'BTreeSet<ActorInRole>' // BTreeSet<ActorInRole>
       },
       UserInfo,
       CheckedUserInfo: {
@@ -112,10 +122,7 @@ export function registerMembershipTypes () {
       },
       Role,
       ActorId,
-      ActorInRole: {
-        role: 'Role',
-        actor_id: 'ActorId'
-      },
+      ActorInRole,
     });
   } catch (err) {
     console.error('Failed to register custom types of membership module', err);

--- a/packages/joy-types/src/mint/index.ts
+++ b/packages/joy-types/src/mint/index.ts
@@ -7,6 +7,7 @@ export class MintId extends u64 {};
 export class Setting extends u128 {};
 export class Adding extends u128 {};
 export class Reducing extends u128 {};
+
 export class AdjustCapacityBy extends Enum {
     constructor (value?: any, index?: number) {
         super(

--- a/packages/joy-types/src/mint/index.ts
+++ b/packages/joy-types/src/mint/index.ts
@@ -1,0 +1,74 @@
+import { getTypeRegistry, u32, u64, u128, Option, Enum} from '@polkadot/types';
+import { Balance, BlockNumber } from '@polkadot/types/interfaces';
+import { JoyStruct } from '../JoyStruct';
+
+export class MintId extends u64 {};
+
+export class Setting extends u128 {};
+export class Adding extends u128 {};
+export class Reducing extends u128 {};
+export class AdjustCapacityBy extends Enum {
+    constructor (value?: any, index?: number) {
+        super(
+          {
+            Setting,
+            Adding,
+            Reducing
+          },
+          value, index);
+      }
+};
+
+export type IAdjustOnInterval = {
+    block_interval: BlockNumber,
+    adjustment_type: AdjustCapacityBy,
+};
+export class AdjustOnInterval extends JoyStruct<IAdjustOnInterval> {
+    constructor (value?: IAdjustOnInterval) {
+        super({
+            block_interval: u32,
+            adjustment_type: AdjustCapacityBy,
+        }, value);
+    }
+};
+
+export type INextAdjustment = {
+    adjustment: AdjustOnInterval,
+    at_block: BlockNumber,
+};
+export class NextAdjustment extends JoyStruct<INextAdjustment> {
+    constructor (value?: INextAdjustment) {
+        super({
+            adjustment: AdjustOnInterval,
+            at_block: u32,
+        }, value);
+    }
+};
+
+export type IMint = {
+    capacity: Balance,
+    next_adjustment: Option<NextAdjustment>,
+    created_at: BlockNumber,
+    total_minted: Balance,
+};
+export class Mint extends JoyStruct<IMint> {
+    constructor (value?: IMint) {
+        super({
+            capacity: u128,
+            next_adjustment: Option.with(NextAdjustment),
+            created_at: u32,
+            total_minted: u128,
+        }, value);
+    }
+};
+
+export function registerMintTypes () {
+    try {
+      getTypeRegistry().register({
+        MintId,
+        Mint,
+      });
+    } catch (err) {
+      console.error('Failed to register custom types of mint module', err);
+    }
+}

--- a/packages/joy-types/src/recurring-rewards/index.ts
+++ b/packages/joy-types/src/recurring-rewards/index.ts
@@ -1,16 +1,56 @@
-import { getTypeRegistry, u64} from '@polkadot/types';
+import { getTypeRegistry, u32, u64, u128, Option, GenericAccountId } from '@polkadot/types';
+import { AccountId, Balance, BlockNumber } from '@polkadot/types/interfaces';
+import { JoyStruct } from '../JoyStruct';
+import { MintId } from '../mint';
 
 export class RecipientId extends u64 {};
 export class RewardRelationshipId extends u64 {};
+
+export type IRecipient = {
+  total_reward_received: Balance,
+  total_reward_missed: Balance,
+};
+export class Recipient extends JoyStruct<IRecipient> {
+  constructor (value?: IRecipient) {
+    super({
+      total_reward_received: u128,
+      total_reward_missed: u128,
+    }, value);
+  }
+};
+
+export type IRewardRelationship = {
+  recipient: RecipientId,
+  mint_id: MintId,
+  account: AccountId,
+  amount_per_payout: Balance,
+  next_payment_at_block: Option<BlockNumber>,
+  payout_interval: Option<BlockNumber>,
+  total_reward_received: Balance,
+  total_reward_missed: Balance,
+};
+export class RewardRelationship extends JoyStruct<IRewardRelationship> {
+  constructor (value?: IRecipient) {
+    super({
+      recipient: RecipientId,
+      mint_id: MintId,
+      account: GenericAccountId,
+      amount_per_payout: u128,
+      next_payment_at_block: Option.with(u32),
+      payout_interval: Option.with(u32),
+      total_reward_received: u128,
+      total_reward_missed: u128,
+    }, value);
+  }
+};
 
 export function registerRecurringRewardsTypes () {
     try {
       getTypeRegistry().register({
         RecipientId,
         RewardRelationshipId,
-        // todo
-        'Recipient': {},
-        'RewardRelationship': {},
+        Recipient,
+        RewardRelationship
       });
     } catch (err) {
       console.error('Failed to register custom types of recurring rewards module', err);

--- a/packages/joy-types/src/recurring-rewards/index.ts
+++ b/packages/joy-types/src/recurring-rewards/index.ts
@@ -1,0 +1,18 @@
+import { getTypeRegistry, u64} from '@polkadot/types';
+
+export class RecipientId extends u64 {};
+export class RewardRelationshipId extends u64 {};
+
+export function registerRecurringRewardsTypes () {
+    try {
+      getTypeRegistry().register({
+        RecipientId,
+        RewardRelationshipId,
+        // todo
+        'Recipient': {},
+        'RewardRelationship': {},
+      });
+    } catch (err) {
+      console.error('Failed to register custom types of recurring rewards module', err);
+    }
+}

--- a/packages/joy-types/src/stake/index.ts
+++ b/packages/joy-types/src/stake/index.ts
@@ -1,0 +1,111 @@
+import { getTypeRegistry, u32, u64, u128, Enum, Null, BTreeMap, bool } from '@polkadot/types';
+import { JoyStruct } from '../JoyStruct';
+import { BlockNumber, Balance } from '@polkadot/types/interfaces';
+
+// type name clash with "Stake" from council election module.
+// import { Stake } from '..';
+// Will have to rename one of them!
+
+export class StakeId extends u64 {};
+export class SlashId extends u64 {};
+
+export type ISlash = {
+    started_at_block: BlockNumber,
+    is_active: bool,
+    blocks_remaining_in_active_period_for_slashing: BlockNumber,
+    slash_amount: Balance,
+};
+export class Slash extends JoyStruct<ISlash> {
+    constructor (value?: ISlash) {
+        super({
+            started_at_block: u32,
+            is_active: bool,
+            blocks_remaining_in_active_period_for_slashing: u32,
+            slash_amount: u128,
+        }, value);
+    }
+};
+
+export type IUnstakingState = {
+    started_at_block: BlockNumber,
+    is_active: bool,
+    blocks_remaining_in_active_period_for_unstaking: BlockNumber,
+};
+export class UnstakingState extends JoyStruct<IUnstakingState> {
+    constructor (value?: IUnstakingState) {
+        super({
+            started_at_block: u32,
+            is_active: bool,
+            blocks_remaining_in_active_period_for_unstaking: u32,
+        }, value);
+    }
+};
+
+export class Normal extends Null {};
+export class Unstaking extends UnstakingState {};
+export class StakedStatus extends Enum {
+    constructor (value?: any, index?: number) {
+        super(
+          {
+            Normal,
+            Unstaking
+          },
+          value, index);
+    }
+};
+
+export type IStakedState = {
+    staked_amount: Balance,
+    staked_status: StakedStatus,
+    next_slash_id: SlashId,
+    ongoing_slashes: BTreeMap<SlashId, Slash>,
+};
+export class StakedState extends JoyStruct<IStakedState> {
+    constructor (value?: IStakedState) {
+        super({
+            staked_amount: u128,
+            staked_status: StakedStatus,
+            next_slash_id: SlashId,
+            ongoing_slashes: BTreeMap.with(SlashId, Slash),
+        }, value);
+    }
+};
+
+export class NotStaked extends Null {};
+export class Staked extends StakedState {};
+
+export class StakingStatus extends Enum {
+    constructor (value?: any, index?: number) {
+        super(
+          {
+            NotStaked,
+            Staked
+          },
+          value, index);
+    }
+};
+
+export type IStake = {
+    created: BlockNumber,
+    staking_status: StakingStatus
+};
+
+export class Stake extends JoyStruct<IStake> {
+    constructor (value?: IStake) {
+        super({
+            created: u32,
+            staking_status: StakingStatus
+        }, value);
+    }
+}
+
+export function registerStakeTypes () {
+    try {
+      getTypeRegistry().register({
+        StakeId,
+        Stake,
+      });
+    } catch (err) {
+      console.error('Failed to register custom types of stake module', err);
+    }
+}

--- a/packages/joy-types/src/stake/index.ts
+++ b/packages/joy-types/src/stake/index.ts
@@ -2,10 +2,6 @@ import { getTypeRegistry, u32, u64, u128, Enum, Null, BTreeMap, bool } from '@po
 import { JoyStruct } from '../JoyStruct';
 import { BlockNumber, Balance } from '@polkadot/types/interfaces';
 
-// type name clash with "Stake" from council election module.
-// import { Stake } from '..';
-// Will have to rename one of them!
-
 export class StakeId extends u64 {};
 export class SlashId extends u64 {};
 


### PR DESCRIPTION
Adds remaining types following integration of all new modules for Rome.
Can be tested against node/runtime from https://github.com/Joystream/substrate-node-joystream/pull/87 which is still a work in progress as [working group module](https://github.com/Joystream/substrate-runtime-joystream/pull/87) has not yet been finalized 