### PR TITLE
Set new accounts explicitly via MyAccountContext

### DIFF
--- a/packages/app-accounts/src/Overview.tsx
+++ b/packages/app-accounts/src/Overview.tsx
@@ -14,9 +14,7 @@ import { Button, CardGrid } from '@polkadot/react-components';
 
 import CreateModal from './modals/Create';
 import ImportModal from './modals/Import';
-import QrModal from './modals/Qr';
 import Account from './Account';
-import Banner from './Banner';
 import translate from './translate';
 
 interface Props extends ComponentProps, I18nProps {
@@ -39,16 +37,13 @@ async function queryLedger (): Promise<void> {
 function Overview ({ accounts, onStatusChange, t }: Props): React.ReactElement<Props> {
   const [isCreateOpen, setIsCreateOpen] = useState(false);
   const [isImportOpen, setIsImportOpen] = useState(false);
-  const [isQrOpen, setIsQrOpen] = useState(false);
-  const emptyScreen = !(isCreateOpen || isImportOpen || isQrOpen) && accounts && (Object.keys(accounts).length === 0);
+  const emptyScreen = !(isCreateOpen || isImportOpen) && accounts && (Object.keys(accounts).length === 0);
 
   const _toggleCreate = (): void => setIsCreateOpen(!isCreateOpen);
   const _toggleImport = (): void => setIsImportOpen(!isImportOpen);
-  const _toggleQr = (): void => setIsQrOpen(!isQrOpen);
 
   return (
     <CardGrid
-      banner={<Banner />}
       buttons={
         <Button.Group>
           <Button
@@ -64,14 +59,7 @@ function Overview ({ accounts, onStatusChange, t }: Props): React.ReactElement<P
             label={t('Restore JSON')}
             onClick={_toggleImport}
           />
-          <Button.Or />
-          <Button
-            icon='qrcode'
-            isPrimary
-            label={t('Add via Qr')}
-            onClick={_toggleQr}
-          />
-          {isLedger() && (
+         {isLedger() && (
             <>
               <Button.Or />
               <Button
@@ -99,13 +87,7 @@ function Overview ({ accounts, onStatusChange, t }: Props): React.ReactElement<P
           onStatusChange={onStatusChange}
         />
       )}
-      {isQrOpen && (
-        <QrModal
-          onClose={_toggleQr}
-          onStatusChange={onStatusChange}
-        />
-      )}
-      {accounts && Object.keys(accounts).map((address): React.ReactNode => (
+     {accounts && Object.keys(accounts).map((address): React.ReactNode => (
         <Account
           address={address}
           key={address}

--- a/packages/app-accounts/src/modals/Create.tsx
+++ b/packages/app-accounts/src/modals/Create.tsx
@@ -126,8 +126,8 @@ function updateAddress (seed: string, derivePath: string, seedType: SeedType, pa
 export function downloadAccount ({ json, pair }: CreateResult): void {
   const blob = new Blob([JSON.stringify(json)], { type: 'application/json; charset=utf-8' });
 
-  InputAddress.setLastValue('account', pair.address);
   FileSaver.saveAs(blob, `${pair.address}.json`);
+  InputAddress.setLastValue('account', pair.address);
 }
 
 function createAccount (context: MyAccountContextProps, suri: string, pairType: KeypairType, name: string, password: string, success: string): ActionStatus {

--- a/packages/app-accounts/src/modals/Create.tsx
+++ b/packages/app-accounts/src/modals/Create.tsx
@@ -8,7 +8,7 @@ import { CreateResult } from '@polkadot/ui-keyring/types';
 import { KeypairType } from '@polkadot/util-crypto/types';
 import { ModalProps } from '../types';
 
-import { MyAccountContextProps, MyAccountContext } from '@polkadot/joy-utils/MyAccountContext';
+import { MyAccountContextProps, useMyAccount } from '@polkadot/joy-utils/MyAccountContext';
 import FileSaver from 'file-saver';
 import React, { useContext, useState } from 'react';
 import styled from 'styled-components';
@@ -130,7 +130,7 @@ export function downloadAccount ({ json, pair }: CreateResult): void {
   InputAddress.setLastValue('account', pair.address);
 }
 
-function createAccount (context: MyAccountContextProps, suri: string, pairType: KeypairType, name: string, password: string, success: string): ActionStatus {
+function createAccount (suri: string, pairType: KeypairType, name: string, password: string, success: string): ActionStatus {
   // we will fill in all the details below
   const status = { action: 'create' } as ActionStatus;
 
@@ -143,7 +143,6 @@ function createAccount (context: MyAccountContextProps, suri: string, pairType: 
     status.message = success;
 
     downloadAccount(result);
-    context.set(address);
   } catch (error) {
     status.status = 'error';
     status.message = error.message;
@@ -175,14 +174,15 @@ function Create ({ className, onClose, onStatusChange, seed: propsSeed, t, type:
   };
   const _onChangeName = (name: string): void => setName({ isNameValid: !!name.trim(), name });
   const _toggleConfirmation = (): void => setIsConfirmationOpen(!isConfirmationOpen);
-  const context = useContext<MyAccountContextProps>(MyAccountContext);
 
   const _onCommit = (): void => {
     if (!isValid) {
       return;
     }
 
-    const status = createAccount(context, `${seed}${derivePath}`, pairType, name, password, t('created account'));
+    const status = createAccount(`${seed}${derivePath}`, pairType, name, password, t('created account'));
+    const context = useMyAccount()
+    context.set(status.account as string)
 
     _toggleConfirmation();
     onStatusChange(status);

--- a/packages/app-accounts/src/modals/Create.tsx
+++ b/packages/app-accounts/src/modals/Create.tsx
@@ -8,7 +8,7 @@ import { CreateResult } from '@polkadot/ui-keyring/types';
 import { KeypairType } from '@polkadot/util-crypto/types';
 import { ModalProps } from '../types';
 
-import { MyAccountContextProps, useMyAccount } from '@polkadot/joy-utils/MyAccountContext';
+import { useMyAccount } from '@polkadot/joy-utils/MyAccountContext';
 import FileSaver from 'file-saver';
 import React, { useContext, useState } from 'react';
 import styled from 'styled-components';
@@ -174,6 +174,7 @@ function Create ({ className, onClose, onStatusChange, seed: propsSeed, t, type:
   };
   const _onChangeName = (name: string): void => setName({ isNameValid: !!name.trim(), name });
   const _toggleConfirmation = (): void => setIsConfirmationOpen(!isConfirmationOpen);
+  const context = useMyAccount()
 
   const _onCommit = (): void => {
     if (!isValid) {
@@ -181,7 +182,6 @@ function Create ({ className, onClose, onStatusChange, seed: propsSeed, t, type:
     }
 
     const status = createAccount(`${seed}${derivePath}`, pairType, name, password, t('created account'));
-    const context = useMyAccount()
     context.set(status.account as string)
 
     _toggleConfirmation();

--- a/packages/app-accounts/src/modals/Create.tsx
+++ b/packages/app-accounts/src/modals/Create.tsx
@@ -8,6 +8,7 @@ import { CreateResult } from '@polkadot/ui-keyring/types';
 import { KeypairType } from '@polkadot/util-crypto/types';
 import { ModalProps } from '../types';
 
+import { MyAccountContextProps, MyAccountContext } from '@polkadot/joy-utils/MyAccountContext';
 import FileSaver from 'file-saver';
 import React, { useContext, useState } from 'react';
 import styled from 'styled-components';
@@ -125,11 +126,11 @@ function updateAddress (seed: string, derivePath: string, seedType: SeedType, pa
 export function downloadAccount ({ json, pair }: CreateResult): void {
   const blob = new Blob([JSON.stringify(json)], { type: 'application/json; charset=utf-8' });
 
-  FileSaver.saveAs(blob, `${pair.address}.json`);
   InputAddress.setLastValue('account', pair.address);
+  FileSaver.saveAs(blob, `${pair.address}.json`);
 }
 
-function createAccount (suri: string, pairType: KeypairType, name: string, password: string, success: string): ActionStatus {
+function createAccount (context: MyAccountContextProps, suri: string, pairType: KeypairType, name: string, password: string, success: string): ActionStatus {
   // we will fill in all the details below
   const status = { action: 'create' } as ActionStatus;
 
@@ -142,6 +143,7 @@ function createAccount (suri: string, pairType: KeypairType, name: string, passw
     status.message = success;
 
     downloadAccount(result);
+    context.set(address);
   } catch (error) {
     status.status = 'error';
     status.message = error.message;
@@ -173,13 +175,14 @@ function Create ({ className, onClose, onStatusChange, seed: propsSeed, t, type:
   };
   const _onChangeName = (name: string): void => setName({ isNameValid: !!name.trim(), name });
   const _toggleConfirmation = (): void => setIsConfirmationOpen(!isConfirmationOpen);
+  const context = useContext<MyAccountContextProps>(MyAccountContext);
 
   const _onCommit = (): void => {
     if (!isValid) {
       return;
     }
 
-    const status = createAccount(`${seed}${derivePath}`, pairType, name, password, t('created account'));
+    const status = createAccount(context, `${seed}${derivePath}`, pairType, name, password, t('created account'));
 
     _toggleConfirmation();
     onStatusChange(status);

--- a/packages/app-accounts/src/modals/Derive.tsx
+++ b/packages/app-accounts/src/modals/Derive.tsx
@@ -13,6 +13,8 @@ import { useDebounce } from '@polkadot/react-components/hooks';
 import keyring from '@polkadot/ui-keyring';
 import { keyExtractPath } from '@polkadot/util-crypto';
 
+import { useMyAccount } from '@polkadot/joy-utils/MyAccountContext';
+
 import translate from '../translate';
 import { downloadAccount } from './Create';
 import CreateConfirmation from './CreateConfirmation';
@@ -79,6 +81,7 @@ function Derive ({ className, from, onClose, t }: Props): React.ReactElement {
   const [suri, setSuri] = useState('');
   const debouncedSuri = useDebounce(suri);
   const isValid = !!address && !deriveError && isNameValid && isPassValid;
+  const context = useMyAccount()
 
   useEffect((): void => {
     setIsLocked(source.isLocked);
@@ -118,6 +121,7 @@ function Derive ({ className, from, onClose, t }: Props): React.ReactElement {
     }
 
     const status = createAccount(source, suri, name, password, t('created account'));
+    context.set(status.account as string)
 
     _toggleConfirmation();
     queueAction(status);

--- a/packages/app-accounts/src/modals/Import.tsx
+++ b/packages/app-accounts/src/modals/Import.tsx
@@ -8,6 +8,7 @@ import { ActionStatus } from '@polkadot/react-components/Status/types';
 import { ModalProps } from '../types';
 
 import React from 'react';
+import { MyAccountContext} from '@polkadot/joy-utils/MyAccountContext';
 import { AddressRow, Button, InputAddress, InputFile, Modal, Password, TxComponent } from '@polkadot/react-components';
 import { isHex, isObject, u8aToString } from '@polkadot/util';
 import keyring from '@polkadot/ui-keyring';
@@ -25,6 +26,9 @@ interface State {
 }
 
 class Import extends TxComponent<Props, State> {
+  static contextType = MyAccountContext;
+  context!: React.ContextType<typeof MyAccountContext>;
+
   public state: State = {
     address: null,
     isFileValid: false,
@@ -155,6 +159,7 @@ class Import extends TxComponent<Props, State> {
       status.message = t('account restored');
 
       InputAddress.setLastValue('account', address);
+      this.context.set(address)
     } catch (error) {
       this.setState({ isPassValid: false });
 

--- a/packages/app-accounts/src/modals/Qr.tsx
+++ b/packages/app-accounts/src/modals/Qr.tsx
@@ -11,6 +11,8 @@ import { AddressRow, Button, Input, InputAddress, Modal } from '@polkadot/react-
 import { QrScanAddress } from '@polkadot/react-qr';
 import keyring from '@polkadot/ui-keyring';
 
+import { useMyAccount } from '@polkadot/joy-utils/MyAccountContext';
+
 import translate from '../translate';
 
 interface Scanned {
@@ -25,8 +27,10 @@ interface Props extends I18nProps, ModalProps {
 function QrModal ({ className, onClose, onStatusChange, t }: Props): React.ReactElement<Props> {
   const [{ isNameValid, name }, setName] = useState({ isNameValid: false, name: '' });
   const [scanned, setScanned] = useState<Scanned | null>(null);
+  const context = useMyAccount()
 
   const _onNameChange = (name: string): void => setName({ isNameValid: !!name.trim(), name });
+
   const _onSave = (): void => {
     if (!scanned || !isNameValid) {
       return;
@@ -36,6 +40,7 @@ function QrModal ({ className, onClose, onStatusChange, t }: Props): React.React
 
     keyring.addExternal(address, { genesisHash, name: name.trim() });
     InputAddress.setLastValue('account', address);
+    context.set(address)
 
     onStatusChange({
       account: address,


### PR DESCRIPTION
Closes #260 

At some point during development, the link (which seems to have been via a `Subscribable`) between `MyAccountContext` and the account creation screen was lost. 

This meant that the first account created was not being stored as the 'active' account in local storage, and the accounts selector dropdown in the top bar was not being populated.

This small patch makes use of `MyAccountContext` in the `Create` modal of the `accounts` application to properly the context value.