### PR TITLE
BTreeSet workaround

### DIFF
--- a/packages/joy-types/src/content-working-group/index.ts
+++ b/packages/joy-types/src/content-working-group/index.ts
@@ -368,6 +368,7 @@ export function registerContentWorkingGroupTypes () {
         Principal,
         WorkingGroupUnstaker,
 		CuratorApplicationIdToCuratorIdMap, 
+		CuratorApplicationIdSet: Vec.with(CuratorApplicationId), 
       });
     } catch (err) {
       console.error('Failed to register custom types of content working group module', err);


### PR DESCRIPTION
This is a workaround for a required BTreeSet extrinsic call in the curators working group defined in the runtime. This requires https://github.com/Joystream/substrate-runtime-joystream/pull/135 for the runtime implementation. 