### PR TITLE
Default TxButton to live mode, unless a mock transport is used

### DIFF
--- a/packages/joy-utils/src/TxButton.tsx
+++ b/packages/joy-utils/src/TxButton.tsx
@@ -8,7 +8,7 @@ import { withApi } from '@polkadot/react-api/index';
 import { assert } from '@polkadot/util';
 import { withMyAccount, MyAccountProps } from '@polkadot/joy-utils/MyAccount';
 import { useTransportContext } from '@polkadot/joy-media/MediaView';
-import { SubstrateTransport } from '@polkadot/joy-media/transport.substrate';
+import { MockTransport } from '@polkadot/joy-media/transport.mock';
 import { Button$Sizes } from '@polkadot/react-components/Button/types';
 
 type InjectedProps = {
@@ -105,11 +105,11 @@ function MockTxButton (props: Props) {
 }
 
 function ResolvedButton (props: Props) {
-  const isSubstrate = useTransportContext() instanceof SubstrateTransport;
+  const isMock = useTransportContext() instanceof MockTransport;
 
-  const Component = isSubstrate
-    ? withApi(withMyAccount(TxButton))
-    : MockTxButton;
+  const Component = isMock
+    ? MockTxButton
+    : withApi(withMyAccount(TxButton));
 
   return <Component {...props} />;
 }


### PR DESCRIPTION
This allows packages other than `joy-media` to use`TxButton`.