### PR TITLE
Fix reversed ranks in application display

### DIFF
--- a/packages/joy-roles/src/transport.substrate.ts
+++ b/packages/joy-roles/src/transport.substrate.ts
@@ -429,10 +429,10 @@ export class Transport extends TransportBase implements ITransport {
       if (a.value.eq(b.value)) {
         return 0
       } else if (a.value.gt(b.value)) {
-        return 1
+        return -1
       }
 
-      return 0
+      return 1
     })
 
     return appvalues.findIndex(v => v.app.eq(myApp)) + 1


### PR DESCRIPTION
The sorting algorithm here was broken; instead of the applicant's current rank, it was giving them their rank in reverse. 