### PR TITLE
joy-election: listen to event on correct 'section'

### DIFF
--- a/packages/joy-election/src/VoteForm.tsx
+++ b/packages/joy-election/src/VoteForm.tsx
@@ -184,7 +184,7 @@ class Component extends React.PureComponent<Props, State> {
     let hasVotedEvent = false;
     txResult.events.forEach((event, i) => {
       const { section, method } = event.event;
-      if (section === 'election' && method === 'Voted') {
+      if (section === 'councilElection' && method === 'Voted') {
         hasVotedEvent = true;
       }
     });


### PR DESCRIPTION
Problem: @bwhm observed that council election votes were not being saved.

Issue:
In newer substrate the way section is populated in api changed slightly, which broke the event handler looking for `Voted` event after successful vote tx is complete.

The votes is only saved to local storage on success, and this is why the vote was not being saved.

Fixed in this PR.