### PR TITLE
Proposal forms error handling and some minor fixes

### DIFF
--- a/packages/joy-proposals/src/forms/EvictStorageProviderForm.tsx
+++ b/packages/joy-proposals/src/forms/EvictStorageProviderForm.tsx
@@ -1,6 +1,7 @@
 import React from "react";
 import { FormikProps } from "formik";
-import { Form, Icon, Button, Dropdown } from "semantic-ui-react";
+import { Form, Icon, Button, Dropdown, Label } from "semantic-ui-react";
+import { getFormErrorLabelsProps } from './errorHandling';
 import * as Yup from "yup";
 
 import { withFormContainer } from "./FormContainer";
@@ -16,23 +17,26 @@ interface FormValues {
   storageProvider: any;
 }
 function EvictStorageProviderForm(props: EvictStorageProviderProps & FormikProps<FormValues>) {
-  const { handleChange, storageProviders } = props;
+  const { handleChange, storageProviders, errors, touched, handleSubmit } = props;
+  const errorLabelsProps = getFormErrorLabelsProps<FormValues>(errors, touched);
   return (
     <div className="Forms">
-      <Form className="proposal-form">
+      <Form className="proposal-form" onSubmit={ handleSubmit }>
         <Form.Input
           onChange={handleChange}
           label="Title"
           name="title"
           placeholder="Title for your awesome proposal..."
+          error={ errorLabelsProps.title }
         />
         <Form.TextArea
           onChange={handleChange}
           label="Rationale"
           name="rationale"
           placeholder="This proposal is awesome because..."
+          error={ errorLabelsProps.rationale }
         />
-        <Form.Field>
+        <Form.Field error={ Boolean(errorLabelsProps.storageProvider) }>
           <label>Storage Provider</label>
           <Dropdown
             clearable
@@ -41,7 +45,9 @@ function EvictStorageProviderForm(props: EvictStorageProviderProps & FormikProps
             fluid
             selection
             options={storageProviders}
+            onChange={handleChange}
           />
+          { errorLabelsProps.storageProvider && <Label { ...errorLabelsProps.storageProvider } prompt/> }
         </Form.Field>
         <div className="form-buttons">
           <Button type="submit" color="blue">
@@ -66,11 +72,13 @@ type OuterFormProps = {
 export default withFormContainer<OuterFormProps, FormValues>({
   mapPropsToValues: () => ({
     title: "",
-    rationale: ""
+    rationale: "",
+    storageProvider: "",
   }),
   validationSchema: Yup.object().shape({
     title: Yup.string().required("Title is required!"),
-    rationale: Yup.string().required("Rationale is required!")
+    rationale: Yup.string().required("Rationale is required!"),
+    storageProvider: Yup.string().required("Select a storage provider!")
   }),
   handleSubmit: (values, { setSubmitting }) => {
     setTimeout(() => {

--- a/packages/joy-proposals/src/forms/SignalForm.tsx
+++ b/packages/joy-proposals/src/forms/SignalForm.tsx
@@ -1,6 +1,7 @@
 import React from "react";
 import { FormikProps } from "formik";
 import { Form, Icon, Button } from "semantic-ui-react";
+import { getFormErrorLabelsProps } from './errorHandling';
 import * as Yup from "yup";
 
 import { withFormContainer } from "./FormContainer";
@@ -15,27 +16,31 @@ interface FormValues {
 }
 
 function SignalForm(props: SignalFormProps & FormikProps<FormValues>) {
-  const { handleChange } = props;
+  const { handleChange, errors, touched, handleSubmit } = props;
+  const errorLabelsProps = getFormErrorLabelsProps<FormValues>(errors, touched);
   return (
     <div className="Forms">
-      <Form className="proposal-form">
+      <Form className="proposal-form" onSubmit={handleSubmit}>
         <Form.Input
           onChange={handleChange}
           label="Title"
           name="title"
           placeholder="Title for your awesome proposal..."
+          error={ errorLabelsProps.title }
         />
         <Form.TextArea
           onChange={handleChange}
           label="Description"
           name="description"
           placeholder="What I would like to propose is..."
+          error={ errorLabelsProps.description }
         />
         <Form.TextArea
           onChange={handleChange}
           label="Rationale"
           name="rationale"
           placeholder="This proposal is awesome because..."
+          error={ errorLabelsProps.rationale }
         />
         <div className="form-buttons">
           <Button type="submit" color="blue">

--- a/packages/joy-proposals/src/forms/SpendingProposalForm.tsx
+++ b/packages/joy-proposals/src/forms/SpendingProposalForm.tsx
@@ -1,6 +1,7 @@
 import React from "react";
 import { FormikProps } from "formik";
-import { Form, Icon, Button, Dropdown } from "semantic-ui-react";
+import { Form, Icon, Button, Dropdown, Label } from "semantic-ui-react";
+import { getFormErrorLabelsProps } from './errorHandling';
 import * as Yup from "yup";
 
 import { withFormContainer } from "./FormContainer";
@@ -18,33 +19,38 @@ interface FormValues {
 }
 
 function SpendingProposalForm(props: SpendingProposalProps & FormikProps<FormValues>) {
-  const { handleChange, destinationAccounts } = props;
+  const { handleChange, destinationAccounts, errors, touched, handleSubmit } = props;
+  const errorLabelsProps = getFormErrorLabelsProps<FormValues>(errors, touched);
   return (
     <div className="Forms">
-      <Form className="proposal-form">
+      <Form className="proposal-form" onSubmit={handleSubmit}>
         <Form.Input
           onChange={handleChange}
           label="Title"
           name="title"
           placeholder="Title for your awesome proposal..."
+          error={errorLabelsProps.title}
         />
         <Form.TextArea
           onChange={handleChange}
           label="Rationale"
           name="rationale"
           placeholder="This proposal is awesome because..."
+          error={errorLabelsProps.rationale}
         />
-        <div style={{ display: "flex" }}>
-          <Form.Input
-            onChange={handleChange}
-            className="tokens"
-            label="Amount of tokens"
-            name="tokens"
-            placeholder="100"
-          />
-          <div style={{ margin: "2.5rem 0 2.5rem 1rem" }}>tJOY</div>
-        </div>
-        <Form.Field>
+        <Form.Input
+          style={{ display: 'flex', alignItems: 'center' }}
+          onChange={handleChange}
+          className="tokens"
+          label="Amount of tokens"
+          name="tokens"
+          placeholder="100"
+          error={ errorLabelsProps.tokens }
+        >
+          <input />
+          <div style={{ margin: "0 0 0 1rem" }}>tJOY</div>
+        </Form.Input>
+        <Form.Field error={Boolean(errorLabelsProps.destinationAccount)}>
           <label>Destination Account</label>
           <Dropdown
             clearable
@@ -54,7 +60,9 @@ function SpendingProposalForm(props: SpendingProposalProps & FormikProps<FormVal
             fluid
             selection
             options={destinationAccounts}
+            onChange={handleChange}
           />
+          { errorLabelsProps.destinationAccount && <Label { ...errorLabelsProps.destinationAccount } prompt/> }
         </Form.Field>
 
         <div className="form-buttons">
@@ -82,13 +90,14 @@ export default withFormContainer<OuterFormProps, FormValues>({
   mapPropsToValues: () => ({
     title: "",
     rationale: "",
-    tokens: 0
+    tokens: "",
+    destinationAccount: ""
   }),
   validationSchema: Yup.object().shape({
     title: Yup.string().required("Title is required!"),
     rationale: Yup.string().required("Rationale is required!"),
     tokens: Yup.number().required("You need to specify an amount of tokens."),
-    destinationAccount: Yup.string()
+    destinationAccount: Yup.string().required('Select a destination account!')
   }),
   handleSubmit: (values, { setSubmitting }) => {
     console.log(JSON.stringify(values, null, 2));

--- a/packages/joy-proposals/src/forms/errorHandling.ts
+++ b/packages/joy-proposals/src/forms/errorHandling.ts
@@ -1,0 +1,37 @@
+import { FormikErrors, FormikTouched } from "formik";
+import { LabelProps } from "semantic-ui-react";
+
+type FieldErrorLabelProps = LabelProps | null; // This is used for displaying semantic-ui errors
+type FormErrorLabelsProps<ValuesT> = { [T in keyof ValuesT]: FieldErrorLabelProps };
+
+// Single form field error state.
+// Takes formik "errors" and "touched" objects and the field name as arguments.
+// Returns value to use ie. in the semantic-ui Form.Input error prop.
+export function getErrorLabelProps<ValuesT>(
+  errors: FormikErrors<ValuesT>,
+  touched: FormikTouched<ValuesT>,
+  fieldName: keyof ValuesT,
+  pointing: LabelProps["pointing"] = 'above'
+
+): FieldErrorLabelProps
+{
+  return (errors[fieldName] && touched[fieldName]) ?
+    { content: errors[fieldName], pointing }
+    : null;
+}
+
+// All form fields error states (uses default value for "pointing").
+// Takes formik "errors" and "touched" objects as arguments.
+// Returns object with field names as properties and values that can be used ie. for semantic-ui Form.Input error prop
+export function getFormErrorLabelsProps<ValuesT>(
+  errors: FormikErrors<ValuesT>,
+  touched: FormikTouched<ValuesT>
+): FormErrorLabelsProps<ValuesT>
+{
+  let errorStates: Partial<FormErrorLabelsProps<ValuesT>> = {};
+  for (let fieldName in errors) {
+    errorStates[fieldName] = getErrorLabelProps<ValuesT>(errors, touched, fieldName);
+  }
+
+  return <FormErrorLabelsProps<ValuesT>> errorStates;
+}

--- a/packages/joy-proposals/src/stories/ProposalForms.stories.tsx
+++ b/packages/joy-proposals/src/stories/ProposalForms.stories.tsx
@@ -61,31 +61,31 @@ const destinationAccounts = [
   {
     key: "Elliot Fu",
     text: "Elliot Fu",
-    value: "0x555",
+    value: "0x666",
     image: { avatar: true, src: "https://react.semantic-ui.com/images/avatar/small/elliot.jpg" }
   },
   {
     key: "Stevie Feliciano",
     text: "Stevie Feliciano",
-    value: "0x555",
+    value: "0x777",
     image: { avatar: true, src: "https://react.semantic-ui.com/images/avatar/small/stevie.jpg" }
   },
   {
     key: "Christian",
     text: "Christian",
-    value: "0x555",
+    value: "0x888",
     image: { avatar: true, src: "https://react.semantic-ui.com/images/avatar/small/christian.jpg" }
   },
   {
     key: "Matt",
     text: "Matt",
-    value: "0x555",
+    value: "0x999",
     image: { avatar: true, src: "https://react.semantic-ui.com/images/avatar/small/elliot.jpg" }
   },
   {
     key: "Justen Kitsune",
     text: "Justen Kitsune",
-    value: "0x555",
+    value: "0x000",
     image: { avatar: true, src: "https://react.semantic-ui.com/images/avatar/small/steve.jpg" }
   }
 ];


### PR DESCRIPTION
I added the error handling (in `EvictStorageProposalForm`, `SignalForm` and `SpendingProposalForm`), connected the form submit handler and fixed a few minor issues, ie.:
1. All `destinationAccounts` in `ProposalForms.stories.tsx` seemed to have the same `value` so no matter which account I chose it ended up beeing "Jenny Hess".
2. Dropdown fields were not included in `mapPropsToValues` and `validationSchema`, they also didn't have the `onChange` prop, so they ended up not beeing validated.
3. I changed the default value for `tokens` in `SpendingProposalForm` to be an empty string instead of `0` (otherwise it wasn't causing an error if the form was submitted with no value provided for this field and I'm guessing it should).
4. I made a minor change in `tokens` field display in `SpendingProposalForm` because the old approach didn't work too well with `error` prop beeing set on the `Form.Input`