### PR TITLE
Proposal Forms: Help tooltips

### DIFF
--- a/packages/joy-proposals/src/forms/EvictStorageProviderForm.tsx
+++ b/packages/joy-proposals/src/forms/EvictStorageProviderForm.tsx
@@ -3,6 +3,7 @@ import { FormikProps } from "formik";
 import { Form, Icon, Button, Dropdown, Label } from "semantic-ui-react";
 import { getFormErrorLabelsProps } from "./errorHandling";
 import * as Yup from "yup";
+import LabelWithHelp from './LabelWithHelp';
 
 import { withFormContainer } from "./FormContainer";
 import "./forms.css";
@@ -22,22 +23,26 @@ function EvictStorageProviderForm(props: EvictStorageProviderProps & FormikProps
   return (
     <div className="Forms">
       <Form className="proposal-form" onSubmit={handleSubmit}>
-        <Form.Input
-          onChange={handleChange}
-          label="Title"
-          name="title"
-          placeholder="Title for your awesome proposal..."
-          error={errorLabelsProps.title}
-        />
-        <Form.TextArea
-          onChange={handleChange}
-          label="Rationale"
-          name="rationale"
-          placeholder="This proposal is awesome because..."
-          error={errorLabelsProps.rationale}
-        />
+        <Form.Field error={Boolean(errorLabelsProps.title)}>
+          <LabelWithHelp text="Title" help="The title of your proposal"/>
+          <Form.Input
+            onChange={handleChange}
+            name="title"
+            placeholder="Title for your awesome proposal..."
+            error={errorLabelsProps.title}
+          />
+        </Form.Field>
+        <Form.Field error={Boolean(errorLabelsProps.rationale)}>
+          <LabelWithHelp text="Rationale" help="The rationale behind your proposal"/>
+          <Form.TextArea
+            onChange={handleChange}
+            name="rationale"
+            placeholder="This proposal is awesome because..."
+            error={errorLabelsProps.rationale}
+          />
+        </Form.Field>
         <Form.Field error={Boolean(errorLabelsProps.storageProvider)}>
-          <label>Storage Provider</label>
+          <LabelWithHelp text="Storage provider" help="The storage provider you propose to evict"/>
           <Dropdown
             clearable
             name="storageProvider"

--- a/packages/joy-proposals/src/forms/LabelWithHelp.tsx
+++ b/packages/joy-proposals/src/forms/LabelWithHelp.tsx
@@ -7,14 +7,14 @@ export default function LabelWithHelp(props: LabelWithHelpProps) {
   const [open, setOpen] = useState(false);
   return (
     <label
-      style={{ position: 'relative', cursor: 'pointer' }}
+      style={{ position: 'relative', cursor: 'pointer', padding: '0.25em 0' }}
       onMouseEnter={ () => setOpen(true) }
       onMouseLeave={ () => setOpen(false) }
       >
       {props.text}
       <span style={{ position: "absolute", display: "inline-flex", flexWrap: "wrap", marginTop: "-0.25em" }}>
         <Icon
-          style={{ margin: '0.25em 0.1em 0.25em 0.25em' }}
+          style={{ margin: '0.25em 0.1em 0.5em 0.25em' }}
           name="help circle"
           color="grey"/>
         <Transition animation="fade" visible={open} duration={500}>

--- a/packages/joy-proposals/src/forms/LabelWithHelp.tsx
+++ b/packages/joy-proposals/src/forms/LabelWithHelp.tsx
@@ -1,0 +1,26 @@
+import React, { useState } from "react";
+import { Icon, Label, Transition } from "semantic-ui-react";
+
+type LabelWithHelpProps = { text:string, help: string };
+
+export default function LabelWithHelp(props: LabelWithHelpProps) {
+  const [open, setOpen] = useState(false);
+  return (
+    <label
+      style={{ position: 'relative', cursor: 'pointer' }}
+      onMouseEnter={ () => setOpen(true) }
+      onMouseLeave={ () => setOpen(false) }
+      >
+      {props.text}
+      <span style={{ position: "absolute", display: "inline-flex", flexWrap: "wrap", marginTop: "-0.25em" }}>
+        <Icon
+          style={{ margin: '0.25em 0.1em 0.25em 0.25em' }}
+          name="help circle"
+          color="grey"/>
+        <Transition animation="fade" visible={open} duration={500}>
+          <Label basic style={{ minWidth: '150px' }} color="grey" content={props.help}/>
+        </Transition>
+      </span>
+    </label>
+  );
+}

--- a/packages/joy-proposals/src/forms/MintCapacityForm.tsx
+++ b/packages/joy-proposals/src/forms/MintCapacityForm.tsx
@@ -3,6 +3,7 @@ import { FormikProps } from "formik";
 import { Form, Icon, Button, Dropdown } from "semantic-ui-react";
 import * as Yup from "yup";
 import { getFormErrorLabelsProps } from "./errorHandling";
+import LabelWithHelp from './LabelWithHelp';
 
 import { withFormContainer } from "./FormContainer";
 import "./forms.css";
@@ -23,31 +24,38 @@ function MintCapacityForm(props: MintCapacityProps & FormikProps<FormValues>) {
   return (
     <div className="Forms">
       <Form className="proposal-form" onSubmit={handleSubmit}>
-        <Form.Input
-          onChange={handleChange}
-          label="Title"
-          name="title"
-          placeholder="Title for your awesome proposal..."
-          error={errorLabelsProps.title}
-        />
-        <Form.TextArea
-          onChange={handleChange}
-          label="Rationale"
-          name="rationale"
-          placeholder="This proposal is awesome because..."
-          error={errorLabelsProps.rationale}
-        />
-        <div style={{ display: "flex", alignItems: "center" }}>
+        <Form.Field error={Boolean(errorLabelsProps.title)}>
+          <LabelWithHelp text="Title" help="The title of your proposal"/>
           <Form.Input
             onChange={handleChange}
+            name="title"
+            placeholder="Title for your awesome proposal..."
+            error={errorLabelsProps.title}
+          />
+        </Form.Field>
+        <Form.Field error={Boolean(errorLabelsProps.rationale)}>
+          <LabelWithHelp text="Rationale" help="The rationale behind your proposal"/>
+          <Form.TextArea
+            onChange={handleChange}
+            name="rationale"
+            placeholder="This proposal is awesome because..."
+            error={errorLabelsProps.rationale}
+          />
+        </Form.Field>
+        <Form.Field error={Boolean(errorLabelsProps.capacity)}>
+          <LabelWithHelp text="New Mint Capacity" help="The new mint capacity you propse"/>
+          <Form.Input
+            style={{ display: "flex", alignItems: "center" }}
+            onChange={handleChange}
             className="capacity"
-            label="New Mint Capacity"
             name="capacity"
             placeholder="100"
             error={errorLabelsProps.capacity}
-          />
-          <div style={{ margin: "0 0 0 1rem" }}>tJOY</div>
-        </div>
+          >
+            <input />
+            <div style={{ margin: "0 0 0 1rem" }}>tJOY</div>
+          </Form.Input>
+        </Form.Field>
 
         <div className="form-buttons">
           <Button type="submit" color="blue" loading={isSubmitting}>

--- a/packages/joy-proposals/src/forms/MintCapacityForm.tsx
+++ b/packages/joy-proposals/src/forms/MintCapacityForm.tsx
@@ -82,7 +82,7 @@ export default withFormContainer<OuterFormProps, FormValues>({
   mapPropsToValues: () => ({
     title: "",
     rationale: "",
-    capacity: 0
+    capacity: ""
   }),
   validationSchema: Yup.object().shape({
     title: Yup.string().required("Title is required!"),

--- a/packages/joy-proposals/src/forms/SetCouncilParamsForm.tsx
+++ b/packages/joy-proposals/src/forms/SetCouncilParamsForm.tsx
@@ -6,6 +6,7 @@ import * as Yup from "yup";
 
 import { withFormContainer } from "./FormContainer";
 import "./forms.css";
+import LabelWithHelp from "./LabelWithHelp";
 
 type SetCouncilParamsProps = {
   handleClear: () => void;
@@ -30,90 +31,111 @@ function SetCouncilParamsForm(props: SetCouncilParamsProps & FormikProps<FormVal
   return (
     <div className="Forms">
       <Form className="proposal-form" onSubmit={handleSubmit}>
-        <Form.Input
-          onChange={handleChange}
-          label="Title"
-          name="title"
-          placeholder="Title for your awesome proposal..."
-          error={errorLabelsProps.title}
-        />
-        <Form.TextArea
-          onChange={handleChange}
-          label="Rationale"
-          name="rationale"
-          placeholder="This proposal is awesome because..."
-          error={errorLabelsProps.rationale}
-        />
+        <Form.Field error={Boolean(errorLabelsProps.title)}>
+          <LabelWithHelp text="Title" help="The title of your proposal"/>
+          <Form.Input
+            onChange={handleChange}
+            name="title"
+            placeholder="Title for your awesome proposal..."
+            error={errorLabelsProps.title}
+          />
+        </Form.Field>
+        <Form.Field error={Boolean(errorLabelsProps.rationale)}>
+          <LabelWithHelp text="Rationale" help="The rationale behind your proposal"/>
+          <Form.TextArea
+            onChange={handleChange}
+            name="rationale"
+            placeholder="This proposal is awesome because..."
+            error={errorLabelsProps.rationale}
+          />
+        </Form.Field>
+
         <Divider horizontal>Voting </Divider>
 
         <Form.Group widths="equal" style={{ marginBottom: "8rem" }}>
-          <Form.Input
-            fluid
-            onChange={handleChange}
-            label="Announcing Period"
-            name="announcingPeriod"
-            placeholder="100"
-            error={errorLabelsProps.announcingPeriod}
-          />
-          <Form.Input
-            fluid
-            onChange={handleChange}
-            label="Voting Period"
-            name="votingPeriod"
-            placeholder="(Currently: x days)"
-            error={errorLabelsProps.votingPeriod}
-          />
-          <Form.Input
-            fluid
-            onChange={handleChange}
-            label="Revealing Period"
-            name="revealingPeriod"
-            placeholder="100"
-            error={errorLabelsProps.revealingPeriod}
-          />
-          <Form.Input
-            fluid
-            onChange={handleChange}
-            label="Minimum Voting Stake"
-            name="minVotingStake"
-            placeholder="100"
-            error={errorLabelsProps.minVotingStake}
-          />
+          <Form.Field error={Boolean(errorLabelsProps.announcingPeriod)}>
+            <LabelWithHelp text="Announcing Period" help="Announcing period in days"/>
+            <Form.Input
+              fluid
+              onChange={handleChange}
+              name="announcingPeriod"
+              placeholder="100"
+              error={errorLabelsProps.announcingPeriod}
+            />
+          </Form.Field>
+          <Form.Field error={Boolean(errorLabelsProps.votingPeriod)}>
+            <LabelWithHelp text="Voting Period" help="Voting period in days"/>
+            <Form.Input
+              fluid
+              onChange={handleChange}
+              name="votingPeriod"
+              placeholder="(Currently: x days)"
+              error={errorLabelsProps.votingPeriod}
+            />
+          </Form.Field>
+          <Form.Field error={Boolean(errorLabelsProps.revealingPeriod)}>
+            <LabelWithHelp text="Revealing Period" help="Revealing period in days"/>
+            <Form.Input
+              fluid
+              onChange={handleChange}
+              name="revealingPeriod"
+              placeholder="100"
+              error={errorLabelsProps.revealingPeriod}
+            />
+          </Form.Field>
+          <Form.Field error={Boolean(errorLabelsProps.minVotingStake)}>
+            <LabelWithHelp text="Minimum Voting Stake" help="The minimum voting stake"/>
+            <Form.Input
+              fluid
+              onChange={handleChange}
+              name="minVotingStake"
+              placeholder="100"
+              error={errorLabelsProps.minVotingStake}
+            />
+          </Form.Field>
         </Form.Group>
         <Divider horizontal>Council</Divider>
         <Form.Group widths="equal" style={{ marginBottom: "8rem" }}>
-          <Form.Input
-            fluid
-            onChange={handleChange}
-            label="Minimum Council Stake"
-            name="minCouncilStake"
-            placeholder="100"
-            error={errorLabelsProps.minCouncilStake}
-          />
-          <Form.Input
-            fluid
-            onChange={handleChange}
-            label="New Term Duration"
-            name="newTermDuration"
-            placeholder="100"
-            error={errorLabelsProps.newTermDuration}
-          />
-          <Form.Input
-            fluid
-            onChange={handleChange}
-            label="Council Size"
-            name="councilSize"
-            placeholder="100"
-            error={errorLabelsProps.councilSize}
-          />
-          <Form.Input
-            fluid
-            onChange={handleChange}
-            label="Candidacy Limit"
-            name="candidacyLimit"
-            placeholder="5"
-            error={errorLabelsProps.candidacyLimit}
-          />
+          <Form.Field error={Boolean(errorLabelsProps.minCouncilStake)}>
+            <LabelWithHelp text="Minimum Council Stake" help="The minimum council stake"/>
+            <Form.Input
+              fluid
+              onChange={handleChange}
+              name="minCouncilStake"
+              placeholder="100"
+              error={errorLabelsProps.minCouncilStake}
+            />
+          </Form.Field>
+          <Form.Field error={Boolean(errorLabelsProps.newTermDuration)}>
+            <LabelWithHelp text="New Term Duration" help="Duration of the new term in days"/>
+            <Form.Input
+              fluid
+              onChange={handleChange}
+              name="newTermDuration"
+              placeholder="100"
+              error={errorLabelsProps.newTermDuration}
+            />
+          </Form.Field>
+          <Form.Field error={Boolean(errorLabelsProps.councilSize)}>
+            <LabelWithHelp text="Council Size" help="The size of the council (number of seats)"/>
+            <Form.Input
+              fluid
+              onChange={handleChange}
+              name="councilSize"
+              placeholder="100"
+              error={errorLabelsProps.councilSize}
+            />
+          </Form.Field>
+          <Form.Field error={Boolean(errorLabelsProps.candidacyLimit)}>
+            <LabelWithHelp text="Candidacy Limit" help="How many times can a member candidate"/>
+            <Form.Input
+              fluid
+              onChange={handleChange}
+              name="candidacyLimit"
+              placeholder="5"
+              error={errorLabelsProps.candidacyLimit}
+            />
+          </Form.Field>
         </Form.Group>
 
         <div className="form-buttons">

--- a/packages/joy-proposals/src/forms/SignalForm.tsx
+++ b/packages/joy-proposals/src/forms/SignalForm.tsx
@@ -3,6 +3,7 @@ import { FormikProps } from "formik";
 import { Form, Icon, Button } from "semantic-ui-react";
 import { getFormErrorLabelsProps } from "./errorHandling";
 import * as Yup from "yup";
+import LabelWithHelp from './LabelWithHelp';
 
 import { withFormContainer } from "./FormContainer";
 import "./forms.css";
@@ -21,27 +22,32 @@ function SignalForm(props: SignalFormProps & FormikProps<FormValues>) {
   return (
     <div className="Forms">
       <Form className="proposal-form" onSubmit={handleSubmit}>
-        <Form.Input
-          onChange={handleChange}
-          label="Title"
-          name="title"
-          placeholder="Title for your awesome proposal..."
-          error={errorLabelsProps.title}
-        />
-        <Form.TextArea
-          onChange={handleChange}
-          label="Description"
-          name="description"
-          placeholder="What I would like to propose is..."
-          error={errorLabelsProps.description}
-        />
-        <Form.TextArea
-          onChange={handleChange}
-          label="Rationale"
-          name="rationale"
-          placeholder="This proposal is awesome because..."
-          error={errorLabelsProps.rationale}
-        />
+        <Form.Field error={ Boolean(errorLabelsProps.title) } >
+          <LabelWithHelp text="Title" help="The title of your proposal"/>
+          <Form.Input
+            name="title"
+            placeholder="Title for your awesome proposal..."
+            onChange={handleChange}
+            error={errorLabelsProps.title}/>
+        </Form.Field>
+        <Form.Field error={ Boolean(errorLabelsProps.description) }>
+          <LabelWithHelp text="Description" help="The extensive description of your proposal"/>
+          <Form.TextArea
+            onChange={handleChange}
+            name="description"
+            placeholder="What I would like to propose is..."
+            error={ errorLabelsProps.description }
+          />
+        </Form.Field>
+        <Form.Field error={ Boolean(errorLabelsProps.rationale) }>
+          <LabelWithHelp text="Rationale" help="The rationale behind your proposal"/>
+          <Form.TextArea
+            onChange={handleChange}
+            name="rationale"
+            placeholder="This proposal is awesome because..."
+            error={ errorLabelsProps.rationale }
+          />
+        </Form.Field>
         <div className="form-buttons">
           <Button type="submit" color="blue" loading={isSubmitting}>
             <Icon name="paper plane" />

--- a/packages/joy-proposals/src/forms/SpendingProposalForm.tsx
+++ b/packages/joy-proposals/src/forms/SpendingProposalForm.tsx
@@ -3,6 +3,7 @@ import { FormikProps } from "formik";
 import { Form, Icon, Button, Dropdown, Label } from "semantic-ui-react";
 import { getFormErrorLabelsProps } from "./errorHandling";
 import * as Yup from "yup";
+import LabelWithHelp from './LabelWithHelp';
 
 import { withFormContainer } from "./FormContainer";
 import "./forms.css";
@@ -24,34 +25,40 @@ function SpendingProposalForm(props: SpendingProposalProps & FormikProps<FormVal
   return (
     <div className="Forms">
       <Form className="proposal-form" onSubmit={handleSubmit}>
-        <Form.Input
-          onChange={handleChange}
-          label="Title"
-          name="title"
-          placeholder="Title for your awesome proposal..."
-          error={errorLabelsProps.title}
-        />
-        <Form.TextArea
-          onChange={handleChange}
-          label="Rationale"
-          name="rationale"
-          placeholder="This proposal is awesome because..."
-          error={errorLabelsProps.rationale}
-        />
-        <Form.Input
-          style={{ display: "flex", alignItems: "center" }}
-          onChange={handleChange}
-          className="tokens"
-          label="Amount of tokens"
-          name="tokens"
-          placeholder="100"
-          error={errorLabelsProps.tokens}
-        >
-          <input />
-          <div style={{ margin: "0 0 0 1rem" }}>tJOY</div>
-        </Form.Input>
+        <Form.Field error={Boolean(errorLabelsProps.title)}>
+          <LabelWithHelp text="Title" help="The title of your proposal"/>
+          <Form.Input
+            onChange={handleChange}
+            name="title"
+            placeholder="Title for your awesome proposal..."
+            error={errorLabelsProps.title}
+          />
+        </Form.Field>
+        <Form.Field error={Boolean(errorLabelsProps.rationale)}>
+          <LabelWithHelp text="Rationale" help="The rationale behind your proposal"/>
+          <Form.TextArea
+            onChange={handleChange}
+            name="rationale"
+            placeholder="This proposal is awesome because..."
+            error={errorLabelsProps.rationale}
+          />
+        </Form.Field>
+        <Form.Field error={Boolean(errorLabelsProps.tokens)}>
+          <LabelWithHelp text="Amount of tokens" help="The amount of tokens you propose to spend"/>
+          <Form.Input
+            style={{ display: "flex", alignItems: "center" }}
+            onChange={handleChange}
+            className="tokens"
+            name="tokens"
+            placeholder="100"
+            error={errorLabelsProps.tokens}
+          >
+            <input />
+            <div style={{ margin: "0 0 0 1rem" }}>tJOY</div>
+          </Form.Input>
+        </Form.Field>
         <Form.Field error={Boolean(errorLabelsProps.destinationAccount)}>
-          <label>Destination Account</label>
+          <LabelWithHelp text="Destination account" help="The account you propose to send the tokens into"/>
           <Dropdown
             clearable
             name="destinationAccount"

--- a/packages/joy-proposals/src/forms/errorHandling.ts
+++ b/packages/joy-proposals/src/forms/errorHandling.ts
@@ -11,7 +11,7 @@ export function getErrorLabelProps<ValuesT>(
   errors: FormikErrors<ValuesT>,
   touched: FormikTouched<ValuesT>,
   fieldName: keyof ValuesT,
-  pointing: LabelProps["pointing"] = 'above'
+  pointing: LabelProps["pointing"] = undefined
 
 ): FieldErrorLabelProps
 {


### PR DESCRIPTION
Implemented https://github.com/Joystream/apps/issues/368
I created a `LabelWithHelp` component that can be put inside `Form.Field` along with `Form.Input`, `Form.Textarea` etc.
I put all form fields inside the `Form.Field` component.
I also changed the error display a little bit (there is no arrow pointing to the field anymore).