### PR TITLE
Set content working group lead form + generic proposal form

### DIFF
--- a/packages/joy-proposals/src/forms/GenericProposalForm.tsx
+++ b/packages/joy-proposals/src/forms/GenericProposalForm.tsx
@@ -1,0 +1,80 @@
+import React from "react";
+import { FormikProps, WithFormikConfig } from "formik";
+import { Form, Icon, Button } from "semantic-ui-react";
+import { getFormErrorLabelsProps } from "./errorHandling";
+import * as Yup from "yup";
+import LabelWithHelp from './LabelWithHelp';
+
+export type GenericFormValues = {
+  title: string;
+  rationale: string;
+}
+
+type GenericProposalFormProps = {
+  handleChange: FormikProps<GenericFormValues>["handleChange"],
+  errors: FormikProps<GenericFormValues>["errors"],
+  isSubmitting: FormikProps<GenericFormValues>["isSubmitting"],
+  touched: FormikProps<GenericFormValues>["touched"],
+  handleSubmit: FormikProps<GenericFormValues>["handleSubmit"]
+}
+
+type DefaultGenericFormOptions = WithFormikConfig<GenericProposalFormProps, GenericFormValues>;
+
+export const genericFormDefaultOptions: DefaultGenericFormOptions = {
+  mapPropsToValues: props => ({
+    title: "",
+    rationale: "",
+  }),
+  validationSchema: {
+    title: Yup.string().required("Title is required!"),
+    rationale: Yup.string().required("Rationale is required!"),
+  },
+  handleSubmit: (values, { setSubmitting, resetForm }) => {
+    setTimeout(() => {
+      alert(JSON.stringify(values, null, 2));
+      setSubmitting(false);
+    }, 1000);
+  },
+}
+
+// Generic proposal form with basic structure, "Title" and "Rationale" fields
+// Other fields can be passed as children
+export const GenericProposalForm: React.FunctionComponent<GenericProposalFormProps> = (props) => {
+  const { handleChange, errors, isSubmitting, touched, handleSubmit, children } = props;
+  const errorLabelsProps = getFormErrorLabelsProps<GenericFormValues>(errors, touched);
+  return (
+    <div className="Forms">
+      <Form className="proposal-form" onSubmit={handleSubmit}>
+        <Form.Field error={Boolean(errorLabelsProps.title)}>
+          <LabelWithHelp text="Title" help="The title of your proposal"/>
+          <Form.Input
+            onChange={handleChange}
+            name="title"
+            placeholder="Title for your awesome proposal..."
+            error={errorLabelsProps.title}
+          />
+        </Form.Field>
+        <Form.Field error={Boolean(errorLabelsProps.rationale)}>
+          <LabelWithHelp text="Rationale" help="The rationale behind your proposal"/>
+          <Form.TextArea
+            onChange={handleChange}
+            name="rationale"
+            placeholder="This proposal is awesome because..."
+            error={errorLabelsProps.rationale}
+          />
+        </Form.Field>
+        { children }
+        <div className="form-buttons">
+          <Button type="submit" color="blue" loading={isSubmitting}>
+            <Icon name="paper plane" />
+            Submit
+          </Button>
+          <Button color="grey" icon="times">
+            <Icon name="times" />
+            Cancel
+          </Button>
+        </div>
+      </Form>
+    </div>
+  )
+}

--- a/packages/joy-proposals/src/forms/SetContentWorkingGroupLeadForm.tsx
+++ b/packages/joy-proposals/src/forms/SetContentWorkingGroupLeadForm.tsx
@@ -1,0 +1,62 @@
+import React from "react";
+import { FormikProps } from "formik";
+import { Form, Dropdown, Label } from "semantic-ui-react";
+import { getFormErrorLabelsProps } from "./errorHandling";
+import * as Yup from "yup";
+import LabelWithHelp from './LabelWithHelp';
+import { GenericProposalForm, GenericFormValues, genericFormDefaultOptions } from './GenericProposalForm';
+
+import { withFormContainer } from "./FormContainer";
+import "./forms.css";
+
+type FormValues = GenericFormValues & {
+  workingGroupLead: any;
+}
+
+type SetContentWorkingGroupsLeadFormProps = FormikProps<FormValues> & {
+  members: any[];
+};
+
+const SetContentWorkingGroupsLeadForm: React.FunctionComponent<SetContentWorkingGroupsLeadFormProps> = props => {
+  const { handleChange, members, errors, isSubmitting, touched, handleSubmit } = props;
+  const passProps = { handleChange, errors, isSubmitting, touched, handleSubmit };
+  const errorLabelsProps = getFormErrorLabelsProps<FormValues>(errors, touched);
+  return (
+    <GenericProposalForm {...passProps}>
+      <Form.Field error={Boolean(errorLabelsProps.workingGroupLead)}>
+        <LabelWithHelp
+          text="New Content Working Group Lead"
+          help="The member you propose to set as a new Content Working Group Lead"/>
+        <Dropdown
+          clearable
+          name="workingGroupLead"
+          placeholder="Select a member"
+          fluid
+          selection
+          options={members}
+          onChange={handleChange}
+        />
+        {errorLabelsProps.workingGroupLead && <Label {...errorLabelsProps.workingGroupLead} prompt />}
+      </Form.Field>
+    </GenericProposalForm>
+  );
+}
+
+type OuterFormProps = {
+  initialTitle?: FormValues["title"],
+  initialRationale?: FormValues["rationale"],
+  initialWorkingGroupLead?: FormValues["workingGroupLead"]
+} & SetContentWorkingGroupsLeadFormProps;
+
+export default withFormContainer<OuterFormProps, FormValues>({
+  mapPropsToValues: (props: OuterFormProps) => ({
+    ...(genericFormDefaultOptions.mapPropsToValues || (() => ({})))(props),
+    workingGroupLead: ""
+  }),
+  validationSchema: Yup.object().shape({
+    ...genericFormDefaultOptions.validationSchema,
+    workingGroupLead: Yup.string().required("Select a proposed lead!")
+  }),
+  handleSubmit: genericFormDefaultOptions.handleSubmit,
+  displayName: "SetContentWorkingGroupLeadForm"
+})(SetContentWorkingGroupsLeadForm);

--- a/packages/joy-proposals/src/forms/index.ts
+++ b/packages/joy-proposals/src/forms/index.ts
@@ -3,3 +3,4 @@ export { default as SpendingProposalForm } from "./SpendingProposalForm";
 export { default as EvictStorageProviderForm } from "./EvictStorageProviderForm";
 export { default as MintCapacityForm } from "./MintCapacityForm";
 export { default as SetCouncilParamsForm } from "./SetCouncilParamsForm";
+export { default as SetContentWorkingGroupLeadForm } from "./SetContentWorkingGroupLeadForm";

--- a/packages/joy-proposals/src/stories/ProposalForms.stories.tsx
+++ b/packages/joy-proposals/src/stories/ProposalForms.stories.tsx
@@ -5,7 +5,8 @@ import {
   EvictStorageProviderForm,
   SpendingProposalForm,
   MintCapacityForm,
-  SetCouncilParamsForm
+  SetCouncilParamsForm,
+  SetContentWorkingGroupLeadForm
 } from "../forms";
 
 export default {
@@ -21,6 +22,8 @@ export const SpendingProposal = () => <SpendingProposalForm destinationAccounts=
 export const MintCapacity = () => <MintCapacityForm />;
 
 export const SetCouncilParams = () => <SetCouncilParamsForm />;
+
+export const SetContentWorkingGroupLead = () => <SetContentWorkingGroupLeadForm members={members} />;
 
 var storageProvidersData = [
   {
@@ -60,6 +63,8 @@ var storageProvidersData = [
     image: { avatar: true, src: "https://react.semantic-ui.com/images/avatar/small/steve.jpg" }
   }
 ];
+
+const members = [...storageProvidersData];
 
 const destinationAccounts = [
   {


### PR DESCRIPTION
Related issue: https://github.com/Joystream/apps/issues/347
I created new `SetContentWorkingGroupLeadForm` component based on Wireframes.
I also created `GenericProposalForm` component to simplify creation of remaining forms.
Other already existing proposal forms may also be refactored to use it in the future.