### PR TITLE
SetStorageRoleParamsForm + FormField

### DIFF
--- a/packages/joy-proposals/src/forms/FormField.tsx
+++ b/packages/joy-proposals/src/forms/FormField.tsx
@@ -1,0 +1,41 @@
+import React from "react";
+import { Form, FormInputProps } from "semantic-ui-react";
+import LabelWithHelp from './LabelWithHelp';
+
+type FormFieldProps = FormInputProps & {
+  help?: string,
+  unit?: string
+};
+
+// Generic form field component
+//
+// TODO: Currently it only handles Input fields,
+// but this can be extended for all common form field types.
+//
+// The idea is to provide an easy way of introducing new logic,
+// that will affect all of the exsiting form fields (or all fields of given type)
+// and to easily switch the structure and display of a typical form field.
+export const FormField: React.FunctionComponent<FormFieldProps> = props => {
+  const { error, label, help, onChange, name, placeholder, unit } = props;
+  return (
+    <Form.Field error={Boolean(error)}>
+      { (label && help) ?
+        <LabelWithHelp text={ label.toString() } help={ help }/>
+        : ( label ? <label>{ label.toString() }</label> : null )
+      }
+      <Form.Input
+        fluid
+        onChange={onChange}
+        name={ name }
+        placeholder={ placeholder }
+        error={error}
+        style={ unit ? { display: "flex", alignItems: "center" } : undefined }
+      >
+        <input />
+        { unit && <div style={{ margin: "0 0 0 1rem" }}>{unit}</div> }
+      </Form.Input>
+    </Form.Field>
+  );
+}
+
+export default FormField;

--- a/packages/joy-proposals/src/forms/GenericProposalForm.tsx
+++ b/packages/joy-proposals/src/forms/GenericProposalForm.tsx
@@ -23,12 +23,14 @@ type GenericProposalFormProps = {
   handleSubmit: FormikProps<GenericFormValues>["handleSubmit"]
 }
 
-type DefaultGenericFormOptions = WithFormikConfig<GenericProposalFormProps, GenericFormValues>;
+type GenericProposalFormAdditionalProps = {};
 
-export type DefaultOuterFormProps<FormPropsT, FormValuesT> = FormPropsT & { initialData?: Partial<FormValuesT> };
+type DefaultGenericFormOptions = WithFormikConfig<GenericProposalFormAdditionalProps, GenericFormValues>;
+
+export type DefaultOuterFormProps<FormAdditionalPropsT, FormValuesT> = FormAdditionalPropsT & { initialData?: Partial<FormValuesT> };
 
 export const genericFormDefaultOptions: DefaultGenericFormOptions = {
-  mapPropsToValues: (props:DefaultOuterFormProps<GenericProposalFormProps, GenericFormValues>) => ({
+  mapPropsToValues: (props:DefaultOuterFormProps<GenericProposalFormAdditionalProps, GenericFormValues>) => ({
     ...genericFormDefaultValues,
     ...(props.initialData || {})
   }),

--- a/packages/joy-proposals/src/forms/GenericProposalForm.tsx
+++ b/packages/joy-proposals/src/forms/GenericProposalForm.tsx
@@ -10,6 +10,11 @@ export type GenericFormValues = {
   rationale: string;
 }
 
+export const genericFormDefaultValues: GenericFormValues = {
+  title: '',
+  rationale: '',
+}
+
 type GenericProposalFormProps = {
   handleChange: FormikProps<GenericFormValues>["handleChange"],
   errors: FormikProps<GenericFormValues>["errors"],
@@ -20,10 +25,12 @@ type GenericProposalFormProps = {
 
 type DefaultGenericFormOptions = WithFormikConfig<GenericProposalFormProps, GenericFormValues>;
 
+export type DefaultOuterFormProps<FormPropsT, FormValuesT> = FormPropsT & { initialData?: Partial<FormValuesT> };
+
 export const genericFormDefaultOptions: DefaultGenericFormOptions = {
-  mapPropsToValues: props => ({
-    title: "",
-    rationale: "",
+  mapPropsToValues: (props:DefaultOuterFormProps<GenericProposalFormProps, GenericFormValues>) => ({
+    ...genericFormDefaultValues,
+    ...(props.initialData || {})
   }),
   validationSchema: {
     title: Yup.string().required("Title is required!"),

--- a/packages/joy-proposals/src/forms/GenericProposalForm.tsx
+++ b/packages/joy-proposals/src/forms/GenericProposalForm.tsx
@@ -25,12 +25,14 @@ type GenericProposalFormProps = {
 
 type GenericProposalFormAdditionalProps = {};
 
-type DefaultGenericFormOptions = WithFormikConfig<GenericProposalFormAdditionalProps, GenericFormValues>;
-
 export type DefaultOuterFormProps<FormAdditionalPropsT, FormValuesT> = FormAdditionalPropsT & { initialData?: Partial<FormValuesT> };
 
+type OuterFormProps = DefaultOuterFormProps<GenericProposalFormAdditionalProps, GenericFormValues>;
+
+type DefaultGenericFormOptions = WithFormikConfig<OuterFormProps, GenericFormValues>;
+
 export const genericFormDefaultOptions: DefaultGenericFormOptions = {
-  mapPropsToValues: (props:DefaultOuterFormProps<GenericProposalFormAdditionalProps, GenericFormValues>) => ({
+  mapPropsToValues: (props:OuterFormProps) => ({
     ...genericFormDefaultValues,
     ...(props.initialData || {})
   }),

--- a/packages/joy-proposals/src/forms/SetContentWorkingGroupLeadForm.tsx
+++ b/packages/joy-proposals/src/forms/SetContentWorkingGroupLeadForm.tsx
@@ -4,7 +4,7 @@ import { Form, Dropdown, Label } from "semantic-ui-react";
 import { getFormErrorLabelsProps } from "./errorHandling";
 import * as Yup from "yup";
 import LabelWithHelp from './LabelWithHelp';
-import { GenericProposalForm, GenericFormValues, genericFormDefaultOptions } from './GenericProposalForm';
+import { GenericProposalForm, GenericFormValues, genericFormDefaultOptions, DefaultOuterFormProps } from './GenericProposalForm';
 
 import { withFormContainer } from "./FormContainer";
 import "./forms.css";
@@ -13,9 +13,8 @@ type FormValues = GenericFormValues & {
   workingGroupLead: any;
 }
 
-type SetContentWorkingGroupsLeadFormProps = FormikProps<FormValues> & {
-  members: any[];
-};
+type FromAdditionalProps = { members: any[] };
+type SetContentWorkingGroupsLeadFormProps = FormikProps<FormValues> & FromAdditionalProps;
 
 const SetContentWorkingGroupsLeadForm: React.FunctionComponent<SetContentWorkingGroupsLeadFormProps> = props => {
   const { handleChange, members, errors, isSubmitting, touched, handleSubmit } = props;
@@ -42,11 +41,7 @@ const SetContentWorkingGroupsLeadForm: React.FunctionComponent<SetContentWorking
   );
 }
 
-type OuterFormProps = {
-  initialTitle?: FormValues["title"],
-  initialRationale?: FormValues["rationale"],
-  initialWorkingGroupLead?: FormValues["workingGroupLead"]
-} & SetContentWorkingGroupsLeadFormProps;
+type OuterFormProps = DefaultOuterFormProps<FromAdditionalProps, FormValues>;
 
 export default withFormContainer<OuterFormProps, FormValues>({
   mapPropsToValues: (props: OuterFormProps) => ({

--- a/packages/joy-proposals/src/forms/SetStorageRoleParamsForm.tsx
+++ b/packages/joy-proposals/src/forms/SetStorageRoleParamsForm.tsx
@@ -1,0 +1,84 @@
+import React from "react";
+import { FormikProps } from "formik";
+import { Form, Divider } from "semantic-ui-react";
+import { getFormErrorLabelsProps } from "./errorHandling";
+import * as Yup from "yup";
+import {
+  GenericProposalForm,
+  GenericFormValues,
+  genericFormDefaultOptions,
+  DefaultOuterFormProps,
+  genericFormDefaultValues
+} from './GenericProposalForm';
+import FormField from './FormField';
+import { withFormContainer } from "./FormContainer";
+import "./forms.css";
+
+// TODO: All of those should actually be strings? More research required
+type FormValues = GenericFormValues & {
+  storageProviderCount: number | '',
+  storageProviderReward: number | '',
+  storageProviderStakingLimit: number | '',
+};
+
+const defaultValues:FormValues = {
+  ...genericFormDefaultValues,
+  storageProviderCount: '' as '',
+  storageProviderReward: '' as '',
+  storageProviderStakingLimit: '' as '',
+}
+
+type SetStorageRoleParamsFormProps = FormikProps<FormValues>;
+
+const SetStorageRoleParamsForm: React.FunctionComponent<SetStorageRoleParamsFormProps> = props => {
+  const { handleChange, handleSubmit, isSubmitting, errors, touched } = props;
+  const passProps = { handleChange, errors, isSubmitting, touched, handleSubmit };
+  const errorLabelsProps = getFormErrorLabelsProps<FormValues>(errors, touched);
+  return (
+    <GenericProposalForm {...passProps}>
+        <Divider horizontal>Parameters</Divider>
+        <Form.Group widths="equal" style={{ marginBottom: "8rem" }}>
+          <FormField
+            label="Providers Count"
+            help="The proposed maximum number of active Storage Providers"
+            onChange={handleChange}
+            name="storageProviderCount"
+            placeholder="10"
+            error={errorLabelsProps.storageProviderCount}/>
+          <FormField
+            label="Provider Reward"
+            help="The proposed reward for Storage Providers (every x blocks)"
+            onChange={handleChange}
+            name="storageProviderReward"
+            placeholder="50"
+            error={errorLabelsProps.storageProviderReward}
+            unit={'tJOY'}/>
+          <FormField
+            label="Staking Limit"
+            help="The minimum stake for Storage Providers"
+            onChange={handleChange}
+            name="storageProviderStakingLimit"
+            placeholder="1500"
+            error={errorLabelsProps.storageProviderStakingLimit}
+            unit={'tJOY'}/>
+        </Form.Group>
+    </GenericProposalForm>
+  );
+}
+
+type OuterFormProps = DefaultOuterFormProps<SetStorageRoleParamsFormProps, FormValues>;
+
+export default withFormContainer<OuterFormProps, FormValues>({
+  mapPropsToValues: (props:OuterFormProps) => ({
+    ...defaultValues,
+    ...(props.initialData || {})
+  }),
+  validationSchema: Yup.object().shape({
+    ...genericFormDefaultOptions.validationSchema,
+    storageProviderCount: Yup.number().required('Enter the provider count'),
+    storageProviderReward: Yup.number().required('Enter the reward'),
+    storageProviderStakingLimit: Yup.number().required('Enter the provider staking limit')
+  }),
+  handleSubmit: genericFormDefaultOptions.handleSubmit,
+  displayName: "SetStorageRoleParamsForm"
+})(SetStorageRoleParamsForm);

--- a/packages/joy-proposals/src/forms/SetStorageRoleParamsForm.tsx
+++ b/packages/joy-proposals/src/forms/SetStorageRoleParamsForm.tsx
@@ -28,7 +28,8 @@ const defaultValues:FormValues = {
   storageProviderStakingLimit: '',
 }
 
-type SetStorageRoleParamsFormProps = FormikProps<FormValues>;
+type FormAdditionalProps = {};
+type SetStorageRoleParamsFormProps = FormikProps<FormValues> & FormAdditionalProps;
 
 const SetStorageRoleParamsForm: React.FunctionComponent<SetStorageRoleParamsFormProps> = props => {
   const { handleChange, handleSubmit, isSubmitting, errors, touched } = props;
@@ -66,7 +67,7 @@ const SetStorageRoleParamsForm: React.FunctionComponent<SetStorageRoleParamsForm
   );
 }
 
-type OuterFormProps = DefaultOuterFormProps<SetStorageRoleParamsFormProps, FormValues>;
+type OuterFormProps = DefaultOuterFormProps<FormAdditionalProps, FormValues>;
 
 export default withFormContainer<OuterFormProps, FormValues>({
   mapPropsToValues: (props:OuterFormProps) => ({

--- a/packages/joy-proposals/src/forms/SetStorageRoleParamsForm.tsx
+++ b/packages/joy-proposals/src/forms/SetStorageRoleParamsForm.tsx
@@ -14,18 +14,18 @@ import FormField from './FormField';
 import { withFormContainer } from "./FormContainer";
 import "./forms.css";
 
-// TODO: All of those should actually be strings? More research required
+// All of those are strings, because that's how those values are beeing passed from inputs
 type FormValues = GenericFormValues & {
-  storageProviderCount: number | '',
-  storageProviderReward: number | '',
-  storageProviderStakingLimit: number | '',
+  storageProviderCount: string,
+  storageProviderReward: string,
+  storageProviderStakingLimit: string,
 };
 
 const defaultValues:FormValues = {
   ...genericFormDefaultValues,
-  storageProviderCount: '' as '',
-  storageProviderReward: '' as '',
-  storageProviderStakingLimit: '' as '',
+  storageProviderCount: '',
+  storageProviderReward: '',
+  storageProviderStakingLimit: '',
 }
 
 type SetStorageRoleParamsFormProps = FormikProps<FormValues>;

--- a/packages/joy-proposals/src/forms/index.ts
+++ b/packages/joy-proposals/src/forms/index.ts
@@ -4,3 +4,4 @@ export { default as EvictStorageProviderForm } from "./EvictStorageProviderForm"
 export { default as MintCapacityForm } from "./MintCapacityForm";
 export { default as SetCouncilParamsForm } from "./SetCouncilParamsForm";
 export { default as SetContentWorkingGroupLeadForm } from "./SetContentWorkingGroupLeadForm";
+export { default as SetStorageRoleParamsForm } from "./SetStorageRoleParamsForm"

--- a/packages/joy-proposals/src/stories/ProposalForms.stories.tsx
+++ b/packages/joy-proposals/src/stories/ProposalForms.stories.tsx
@@ -6,7 +6,8 @@ import {
   SpendingProposalForm,
   MintCapacityForm,
   SetCouncilParamsForm,
-  SetContentWorkingGroupLeadForm
+  SetContentWorkingGroupLeadForm,
+  SetStorageRoleParamsForm
 } from "../forms";
 
 export default {
@@ -24,6 +25,8 @@ export const MintCapacity = () => <MintCapacityForm />;
 export const SetCouncilParams = () => <SetCouncilParamsForm />;
 
 export const SetContentWorkingGroupLead = () => <SetContentWorkingGroupLeadForm members={members} />;
+
+export const SetStorageRoleParams = () => <SetStorageRoleParamsForm />;
 
 var storageProvidersData = [
   {


### PR DESCRIPTION
Implemented: https://github.com/Joystream/apps/issues/351 based on https://github.com/Joystream/joystream/issues/241
Introduced a new component: `FormField` that can be later extended in order to be used for all form fields (this is further explained in the component file comment).