### PR TITLE
Proposal form: Content Working Group Mint Capacity (from MintCapacityForm)

### DIFF
--- a/packages/joy-proposals/src/forms/MintCapacityForm.tsx
+++ b/packages/joy-proposals/src/forms/MintCapacityForm.tsx
@@ -1,101 +1,69 @@
 import React from "react";
-import { FormikProps } from "formik";
-import { Form, Icon, Button, Dropdown } from "semantic-ui-react";
+import { FormikProps, WithFormikConfig } from "formik";
 import * as Yup from "yup";
 import { getFormErrorLabelsProps } from "./errorHandling";
-import LabelWithHelp from './LabelWithHelp';
-
+import {
+  GenericProposalForm,
+  GenericFormValues,
+  genericFormDefaultOptions,
+  DefaultOuterFormProps,
+  genericFormDefaultValues
+} from './GenericProposalForm';
+import FormField from "./FormField";
 import { withFormContainer } from "./FormContainer";
 import "./forms.css";
 
-type MintCapacityProps = {
-  handleClear: () => void;
-};
-
-interface FormValues {
-  title: string;
-  rationale: string;
-  capacity: number;
+type FormValues = GenericFormValues & {
+  capacity: string
 }
 
-function MintCapacityForm(props: MintCapacityProps & FormikProps<FormValues>) {
-  const { handleChange, errors, touched, isSubmitting, handleSubmit } = props;
+const defaultValues: FormValues = {
+  ...genericFormDefaultValues,
+  capacity: '',
+};
+
+type MintCapacityGroup = 'Council' | 'Content Working Group';
+
+type FormAdditionalProps = {
+  mintCapacityGroup: MintCapacityGroup
+};
+
+type MintCapacityProps = FormikProps<FormValues> & FormAdditionalProps;
+
+const MintCapacityForm: React.FunctionComponent<MintCapacityProps> = props => {
+  const { handleChange, errors, touched, isSubmitting, handleSubmit, mintCapacityGroup } = props;
+  const passProps = { handleChange, errors, isSubmitting, touched, handleSubmit };
   const errorLabelsProps = getFormErrorLabelsProps<FormValues>(errors, touched);
   return (
-    <div className="Forms">
-      <Form className="proposal-form" onSubmit={handleSubmit}>
-        <Form.Field error={Boolean(errorLabelsProps.title)}>
-          <LabelWithHelp text="Title" help="The title of your proposal"/>
-          <Form.Input
-            onChange={handleChange}
-            name="title"
-            placeholder="Title for your awesome proposal..."
-            error={errorLabelsProps.title}
-          />
-        </Form.Field>
-        <Form.Field error={Boolean(errorLabelsProps.rationale)}>
-          <LabelWithHelp text="Rationale" help="The rationale behind your proposal"/>
-          <Form.TextArea
-            onChange={handleChange}
-            name="rationale"
-            placeholder="This proposal is awesome because..."
-            error={errorLabelsProps.rationale}
-          />
-        </Form.Field>
-        <Form.Field error={Boolean(errorLabelsProps.capacity)}>
-          <LabelWithHelp text="New Mint Capacity" help="The new mint capacity you propse"/>
-          <Form.Input
-            style={{ display: "flex", alignItems: "center" }}
-            onChange={handleChange}
-            className="capacity"
-            name="capacity"
-            placeholder="100"
-            error={errorLabelsProps.capacity}
-          >
-            <input />
-            <div style={{ margin: "0 0 0 1rem" }}>tJOY</div>
-          </Form.Input>
-        </Form.Field>
-
-        <div className="form-buttons">
-          <Button type="submit" color="blue" loading={isSubmitting}>
-            <Icon name="paper plane" />
-            Submit
-          </Button>
-          <Button color="grey" icon="times" type="button">
-            <Icon name="times" />
-            Cancel
-          </Button>
-        </div>
-      </Form>
-    </div>
+    <GenericProposalForm {...passProps}>
+      <FormField
+        error={errorLabelsProps.capacity}
+        onChange={handleChange}
+        name="capacity"
+        placeholder="100"
+        label={ `${ mintCapacityGroup } Mint Capacity` }
+        help={ `The new mint capacity you propse for ${ mintCapacityGroup }` }
+        unit="tJOY"
+      />
+    </GenericProposalForm>
   );
 }
 
-type OuterFormProps = {
-  initialTitle?: string;
-  initialRationale?: string;
-  initialCapacity?: number;
-} & MintCapacityProps;
+type OuterFormProps = DefaultOuterFormProps<FormAdditionalProps, FormValues>;
+type OutermostFormProps = OuterFormProps & { handleSubmit: WithFormikConfig<OuterFormProps, FormValues>["handleSubmit"] };
+export default (props:OutermostFormProps) => {
+  const FormContainer = withFormContainer<OuterFormProps, FormValues>({
+    mapPropsToValues: (props:OuterFormProps) => ({
+      ...defaultValues,
+      ...(props.initialData || {})
+    }),
+    validationSchema: Yup.object().shape({
+      ...genericFormDefaultOptions.validationSchema,
+      capacity: Yup.number().required("You need to specify the mint capacity.")
+    }),
+    handleSubmit: props.handleSubmit,
+    displayName: `${ props.mintCapacityGroup }MintCapacityForm`
+  })(MintCapacityForm);
 
-export default withFormContainer<OuterFormProps, FormValues>({
-  mapPropsToValues: () => ({
-    title: "",
-    rationale: "",
-    capacity: ""
-  }),
-  validationSchema: Yup.object().shape({
-    title: Yup.string().required("Title is required!"),
-    rationale: Yup.string().required("Rationale is required!"),
-    capacity: Yup.number().required("You need to specify a mint capacity for the council."),
-    destinationAccount: Yup.string()
-  }),
-  handleSubmit: (values, { setSubmitting }) => {
-    setTimeout(() => {
-      console.log(JSON.stringify(values, null, 2));
-
-      setSubmitting(false);
-    }, 1000);
-  },
-  displayName: "MintCapacityForm"
-})(MintCapacityForm);
+  return <FormContainer mintCapacityGroup={props.mintCapacityGroup}/>
+}

--- a/packages/joy-proposals/src/forms/SetContentWorkingGroupMintCapForm.tsx
+++ b/packages/joy-proposals/src/forms/SetContentWorkingGroupMintCapForm.tsx
@@ -1,0 +1,11 @@
+import React from 'react';
+import { default as MintCapacityForm } from './MintCapacityForm';
+import { genericFormDefaultOptions } from './GenericProposalForm';
+
+const ContentWorkingGroupMintCapForm = () => (
+    <MintCapacityForm
+      mintCapacityGroup="Content Working Group"
+      handleSubmit={ genericFormDefaultOptions.handleSubmit }/>
+);
+
+export default ContentWorkingGroupMintCapForm;

--- a/packages/joy-proposals/src/forms/SetCouncilMintCapForm.tsx
+++ b/packages/joy-proposals/src/forms/SetCouncilMintCapForm.tsx
@@ -1,0 +1,11 @@
+import React from 'react';
+import { default as MintCapacityForm } from './MintCapacityForm';
+import { genericFormDefaultOptions } from './GenericProposalForm';
+
+const CouncilMintCapForm = () => (
+    <MintCapacityForm
+      mintCapacityGroup="Council"
+      handleSubmit={ genericFormDefaultOptions.handleSubmit }/>
+);
+
+export default CouncilMintCapForm;

--- a/packages/joy-proposals/src/forms/index.ts
+++ b/packages/joy-proposals/src/forms/index.ts
@@ -5,3 +5,5 @@ export { default as MintCapacityForm } from "./MintCapacityForm";
 export { default as SetCouncilParamsForm } from "./SetCouncilParamsForm";
 export { default as SetContentWorkingGroupLeadForm } from "./SetContentWorkingGroupLeadForm";
 export { default as SetStorageRoleParamsForm } from "./SetStorageRoleParamsForm"
+export { default as SetContentWorkingGroupMintCapForm } from './SetContentWorkingGroupMintCapForm';
+export { default as SetCouncilMintCapForm } from './SetCouncilMintCapForm';

--- a/packages/joy-proposals/src/stories/ProposalForms.stories.tsx
+++ b/packages/joy-proposals/src/stories/ProposalForms.stories.tsx
@@ -4,10 +4,11 @@ import {
   SignalForm,
   EvictStorageProviderForm,
   SpendingProposalForm,
-  MintCapacityForm,
   SetCouncilParamsForm,
   SetContentWorkingGroupLeadForm,
-  SetStorageRoleParamsForm
+  SetStorageRoleParamsForm,
+  SetContentWorkingGroupMintCapForm,
+  SetCouncilMintCapForm
 } from "../forms";
 
 export default {
@@ -20,13 +21,15 @@ export const StorageProviders = () => <EvictStorageProviderForm storageProviders
 
 export const SpendingProposal = () => <SpendingProposalForm destinationAccounts={destinationAccounts} />;
 
-export const MintCapacity = () => <MintCapacityForm />;
-
 export const SetCouncilParams = () => <SetCouncilParamsForm />;
 
 export const SetContentWorkingGroupLead = () => <SetContentWorkingGroupLeadForm members={members} />;
 
 export const SetStorageRoleParams = () => <SetStorageRoleParamsForm />;
+
+export const ContentWorkingGroupMintCap = () => <SetContentWorkingGroupMintCapForm />;
+
+export const CouncilMintCap = () => <SetCouncilMintCapForm />;
 
 var storageProvidersData = [
   {


### PR DESCRIPTION
Implements: https://github.com/Joystream/apps/issues/349
Since we already had `MintCapacityForm` which handled setting mint capacity for council, I just made it more customizable and created two separate forms that make use of it (`SetCouncilMintCapForm` and `SetContentWorkingGroupMintCapForm`)