### PR TITLE
Proposal forms: Extrinsics

### DIFF
--- a/packages/joy-proposals/src/forms/EvictStorageProviderForm.tsx
+++ b/packages/joy-proposals/src/forms/EvictStorageProviderForm.tsx
@@ -1,17 +1,22 @@
 import React from "react";
-import { FormikProps } from "formik";
 import { getFormErrorLabelsProps } from "./errorHandling";
 import * as Yup from "yup";
-import { Dropdown, Label } from "semantic-ui-react";
+import { Label } from "semantic-ui-react";
 import {
   GenericProposalForm,
   GenericFormValues,
   genericFormDefaultOptions,
-  DefaultOuterFormProps,
-  genericFormDefaultValues
+  genericFormDefaultValues,
+  withProposalFormData,
+  ProposalFormExportProps,
+  ProposalFormContainerProps,
+  ProposalFormInnerProps
 } from "./GenericProposalForm";
 import { FormField } from "./FormFields";
 import { withFormContainer } from "./FormContainer";
+import { InputAddress } from '@polkadot/react-components/index';
+import { accountIdsToOptions } from "@polkadot/joy-election/utils";
+import { createType } from '@polkadot/types';
 import "./forms.css";
 
 type FormValues = GenericFormValues & {
@@ -23,30 +28,42 @@ const defaultValues: FormValues = {
   storageProvider: ""
 };
 
-type FormAdditionalProps = {
-  storageProviders: any[];
-};
-type EvictStorageProviderFormProps = FormikProps<FormValues> & FormAdditionalProps;
+type FormAdditionalProps = {}; // Aditional props coming all the way from export comonent into the inner form.
+type ExportComponentProps = ProposalFormExportProps<FormAdditionalProps, FormValues>;
+type FormContainerProps = ProposalFormContainerProps<ExportComponentProps>;
+type FormInnerProps = ProposalFormInnerProps<FormContainerProps, FormValues>;
 
-const EvictStorageProviderForm: React.FunctionComponent<EvictStorageProviderFormProps> = props => {
-  const { handleChange, storageProviders, errors, touched, values } = props;
+const EvictStorageProviderForm: React.FunctionComponent<FormInnerProps> = props => {
+  const { errors, touched, values, setFieldValue } = props;
   const errorLabelsProps = getFormErrorLabelsProps<FormValues>(errors, touched);
+  const storageProvidersOptions = accountIdsToOptions([
+    createType("AccountId", "5GrwvaEF5zXb26Fz9rcQpDWS57CtERHpNehXCPcNoHGKutQY") // Alice
+  ]); // TODO: Fetch real storage providers!
   return (
-    <GenericProposalForm {...props}>
+    <GenericProposalForm
+      {...props}
+      txMethod="createEvictStorageProviderProposal"
+      requiredStakePercent={0.1}
+      submitParams={[
+        props.myMemberId,
+        values.title,
+        values.rationale,
+        '{STAKE}',
+        values.storageProvider
+      ]}
+    >
+
       <FormField
         error={errorLabelsProps.storageProvider}
         label="Storage provider"
         help="The storage provider you propose to evict"
       >
-        <Dropdown
-          clearable
-          name="storageProvider"
-          placeholder="Select Storage Provider"
-          fluid
-          selection
-          options={storageProviders}
-          onChange={handleChange}
+        <InputAddress
+          onChange={(address) => setFieldValue("storageProvider", address) }
+          type="address"
+          placeholder="Select storage provider"
           value={values.storageProvider}
+          options={storageProvidersOptions}
         />
         {errorLabelsProps.storageProvider && <Label {...errorLabelsProps.storageProvider} prompt />}
       </FormField>
@@ -54,17 +71,17 @@ const EvictStorageProviderForm: React.FunctionComponent<EvictStorageProviderForm
   );
 };
 
-type OuterFormProps = DefaultOuterFormProps<FormAdditionalProps, FormValues>;
-
-export default withFormContainer<OuterFormProps, FormValues>({
-  mapPropsToValues: (props: OuterFormProps) => ({
+const FormContainer = withFormContainer<FormContainerProps, FormValues>({
+  mapPropsToValues: (props: FormContainerProps) => ({
     ...defaultValues,
     ...(props.initialData || {})
   }),
   validationSchema: Yup.object().shape({
     ...genericFormDefaultOptions.validationSchema,
-    storageProvider: Yup.string().required("Select a storage provider!")
+    storageProvider: Yup.string().nullable().required("Select a storage provider!")
   }),
   handleSubmit: genericFormDefaultOptions.handleSubmit,
   displayName: "EvictStorageProvidersForm"
 })(EvictStorageProviderForm);
+
+export default withProposalFormData<FormContainerProps, ExportComponentProps>(FormContainer);

--- a/packages/joy-proposals/src/forms/GenericProposalForm.tsx
+++ b/packages/joy-proposals/src/forms/GenericProposalForm.tsx
@@ -1,10 +1,21 @@
 import React from "react";
 import { FormikProps, WithFormikConfig } from "formik";
-import { Form, Icon, Button } from "semantic-ui-react";
+import { Form, Icon, Button, Message } from "semantic-ui-react";
 import { getFormErrorLabelsProps } from "./errorHandling";
 import * as Yup from "yup";
 import { InputFormField, TextareaFormField } from "./FormFields";
+import TxButton from '@polkadot/joy-utils/TxButton';
+import { SubmittableResult } from '@polkadot/api';
+import { TxFailedCallback, TxCallback } from '@polkadot/react-components/Status/types';
+import { MyAccountProps, withOnlyMembers } from "@polkadot/joy-utils/MyAccount"
+import { withMulti } from '@polkadot/react-api/with';
+import { withCalls } from '@polkadot/react-api';
+import { CallProps } from '@polkadot/react-api/types';
+import { Balance } from '@polkadot/types/interfaces';
+import { RouteComponentProps } from 'react-router';
+import "./forms.css";
 
+// Generic form values
 export type GenericFormValues = {
   title: string;
   rationale: string;
@@ -15,18 +26,30 @@ export const genericFormDefaultValues: GenericFormValues = {
   rationale: '',
 }
 
-type GenericProposalFormProps = FormikProps<GenericFormValues>;
+// Helper generic types for defining form's Export, Container and Inner component prop types
+export type ProposalFormExportProps<AdditionalPropsT, FormValuesT> = RouteComponentProps & AdditionalPropsT & {
+  initialData?: Partial<FormValuesT>;
+};
+export type ProposalFormContainerProps<ExportPropsT> = ExportPropsT & MyAccountProps & CallProps & {
+  balances_totalIssuance?: Balance;
+};
+export type ProposalFormInnerProps<ContainerPropsT, FormValuesT> = ContainerPropsT & FormikProps<FormValuesT>;
 
-type GenericProposalFormAdditionalProps = {};
 
-export type DefaultOuterFormProps<FormAdditionalPropsT, FormValuesT> = FormAdditionalPropsT & { initialData?: Partial<FormValuesT> };
+// Types only used in this file
+type GenericProposalFormAdditionalProps = {
+  txMethod?: string,
+  submitParams?: any[],
+  requiredStakePercent?: number
+};
 
-type OuterFormProps = DefaultOuterFormProps<GenericProposalFormAdditionalProps, GenericFormValues>;
+type GenericFormContainerProps = ProposalFormContainerProps<ProposalFormExportProps<GenericProposalFormAdditionalProps, GenericFormValues>>;
+type GenericFormInnerProps = ProposalFormInnerProps<GenericFormContainerProps, GenericFormValues>;
+type GenericFormDefaultOptions = WithFormikConfig<GenericFormContainerProps, GenericFormValues>;
 
-type DefaultGenericFormOptions = WithFormikConfig<OuterFormProps, GenericFormValues>;
-
-export const genericFormDefaultOptions: DefaultGenericFormOptions = {
-  mapPropsToValues: (props:OuterFormProps) => ({
+// Default "withFormik" options that can be extended in specific forms
+export const genericFormDefaultOptions: GenericFormDefaultOptions = {
+  mapPropsToValues: (props:GenericFormContainerProps) => ({
     ...genericFormDefaultValues,
     ...(props.initialData || {})
   }),
@@ -35,19 +58,51 @@ export const genericFormDefaultOptions: DefaultGenericFormOptions = {
     rationale: Yup.string().required("Rationale is required!"),
   },
   handleSubmit: (values, { setSubmitting, resetForm }) => {
-    setTimeout(() => {
-      console.log(JSON.stringify(values));
-      resetForm();
-      setSubmitting(false);
-    }, 1000);
+    // This is handled via TxButton
   },
 }
 
 // Generic proposal form with basic structure, "Title" and "Rationale" fields
 // Other fields can be passed as children
-export const GenericProposalForm: React.FunctionComponent<GenericProposalFormProps> = (props) => {
-  const { handleChange, errors, isSubmitting, touched, handleSubmit, children, handleReset, values } = props;
+export const GenericProposalForm: React.FunctionComponent<GenericFormInnerProps> = (props) => {
+  const {
+    handleChange,
+    errors,
+    isSubmitting,
+    touched,
+    handleSubmit,
+    children,
+    handleReset,
+    values,
+    txMethod,
+    submitParams,
+    isValid,
+    setSubmitting,
+    history,
+    balances_totalIssuance,
+    requiredStakePercent
+  } = props;
   const errorLabelsProps = getFormErrorLabelsProps<GenericFormValues>(errors, touched);
+
+  const onSubmit = (sendTx: () => void) => {
+    if (isValid) sendTx();
+  };
+
+  const onTxFailed: TxFailedCallback = (txResult: SubmittableResult | null) => {
+    setSubmitting(false);
+  };
+
+  const onTxSuccess: TxCallback = (txResult: SubmittableResult) => {
+    setSubmitting(false);
+    if (!history) return;
+    history.push('/proposals');
+  };
+
+  const requiredStake: number | undefined = (
+    balances_totalIssuance && requiredStakePercent &&
+    Math.round(balances_totalIssuance.toNumber() * (requiredStakePercent/100))
+  );
+
   return (
     <div className="Forms">
       <Form className="proposal-form" onSubmit={handleSubmit}>
@@ -70,17 +125,47 @@ export const GenericProposalForm: React.FunctionComponent<GenericProposalFormPro
           value={values.rationale}
           />
         { children }
+        <Message warning visible>
+          <Message.Content>
+            <Icon name="warning circle"/>
+            Required stake: <b>{ requiredStake } tJOY</b>
+          </Message.Content>
+        </Message>
         <div className="form-buttons">
-          <Button type="submit" color="blue" loading={isSubmitting}>
-            <Icon name="paper plane" />
-            Submit
-          </Button>
+          { txMethod ? (
+            <TxButton
+              type="submit"
+              label="Submit proposal"
+              isDisabled={ isSubmitting }
+              params={ (submitParams || []).map(p => p === '{STAKE}' ? requiredStake : p ) }
+              tx={ `proposalsCodex.${txMethod}` }
+              onClick={ onSubmit }
+              txFailedCb={ onTxFailed }
+              txSuccessCb={ onTxSuccess }
+            />
+          ) : (
+            <Button type="submit" color="blue" loading={isSubmitting}>
+              <Icon name="paper plane" />
+              Submit
+            </Button>
+          ) }
           <Button type="button" color="grey" icon="times" onClick={handleReset}>
             <Icon name="times" />
-            Cancel
+            Clear
           </Button>
         </div>
       </Form>
     </div>
   )
+}
+
+// Helper that provides additional wrappers for proposal forms
+export function withProposalFormData<ContainerPropsT, ExportPropsT>(FormContainerComponent: React.ComponentType<ContainerPropsT>)
+: React.ComponentType<ExportPropsT>
+{
+  return withMulti(
+    FormContainerComponent,
+    withOnlyMembers,
+    withCalls('query.balances.totalIssuance')
+  );
 }

--- a/packages/joy-proposals/src/forms/RuntimeUpgradeForm.tsx
+++ b/packages/joy-proposals/src/forms/RuntimeUpgradeForm.tsx
@@ -1,13 +1,15 @@
 import React from "react";
-import { FormikProps } from "formik";
 import { Form } from "semantic-ui-react";
 import * as Yup from "yup";
 import {
   GenericProposalForm,
   GenericFormValues,
   genericFormDefaultOptions,
-  DefaultOuterFormProps,
-  genericFormDefaultValues
+  genericFormDefaultValues,
+  withProposalFormData,
+  ProposalFormExportProps,
+  ProposalFormContainerProps,
+  ProposalFormInnerProps
 } from './GenericProposalForm';
 import { withFormContainer } from "./FormContainer";
 import "./forms.css";
@@ -22,13 +24,26 @@ const defaultValues:FormValues = {
   WASM: ''
 }
 
-type FormAdditionalProps = {};
-type RuntimeUpgradeFormProps = FormikProps<FormValues> & FormAdditionalProps;
+type FormAdditionalProps = {}; // Aditional props coming all the way from export comonent into the inner form.
+type ExportComponentProps = ProposalFormExportProps<FormAdditionalProps, FormValues>;
+type FormContainerProps = ProposalFormContainerProps<ExportComponentProps>;
+type FormInnerProps = ProposalFormInnerProps<FormContainerProps, FormValues>;
 
-const RuntimeUpgradeForm: React.FunctionComponent<RuntimeUpgradeFormProps> = props => {
-  const { errors, setFieldValue } = props;
+const RuntimeUpgradeForm: React.FunctionComponent<FormInnerProps> = props => {
+  const { errors, setFieldValue, values } = props;
   return (
-    <GenericProposalForm {...props}>
+    <GenericProposalForm
+      {...props}
+      txMethod="createRuntimeUpgradeProposal"
+      requiredStakePercent={1}
+      submitParams={[
+        props.myMemberId,
+        values.title,
+        values.rationale,
+        '{STAKE}',
+        values.WASM
+      ]}
+    >
       <Form.Field>
         <FileDropdown<FormValues>
           setFieldValue={setFieldValue}
@@ -41,10 +56,8 @@ const RuntimeUpgradeForm: React.FunctionComponent<RuntimeUpgradeFormProps> = pro
   );
 }
 
-type OuterFormProps = DefaultOuterFormProps<FormAdditionalProps, FormValues>;
-
-export default withFormContainer<OuterFormProps, FormValues>({
-  mapPropsToValues: (props:OuterFormProps) => ({
+const FormContainer = withFormContainer<FormContainerProps, FormValues>({
+  mapPropsToValues: (props:FormContainerProps) => ({
     ...defaultValues,
     ...(props.initialData || {})
   }),
@@ -55,3 +68,5 @@ export default withFormContainer<OuterFormProps, FormValues>({
   handleSubmit: genericFormDefaultOptions.handleSubmit,
   displayName: "RuntimeUpgradeForm"
 })(RuntimeUpgradeForm);
+
+export default withProposalFormData(FormContainer);

--- a/packages/joy-proposals/src/forms/SetContentWorkingGroupLeadForm.tsx
+++ b/packages/joy-proposals/src/forms/SetContentWorkingGroupLeadForm.tsx
@@ -1,5 +1,4 @@
 import React from "react";
-import { FormikProps } from "formik";
 import { Dropdown, Label } from "semantic-ui-react";
 import { getFormErrorLabelsProps } from "./errorHandling";
 import * as Yup from "yup";
@@ -7,11 +6,13 @@ import {
   GenericProposalForm,
   GenericFormValues,
   genericFormDefaultOptions,
-  DefaultOuterFormProps,
-  genericFormDefaultValues
+  genericFormDefaultValues,
+  withProposalFormData,
+  ProposalFormExportProps,
+  ProposalFormContainerProps,
+  ProposalFormInnerProps
 } from './GenericProposalForm';
 import { FormField } from './FormFields';
-
 import { withFormContainer } from "./FormContainer";
 import "./forms.css";
 
@@ -24,14 +25,34 @@ const defaultValues: FormValues = {
   workingGroupLead: ''
 }
 
-type FormAdditionalProps = { members: any[] };
-type SetContentWorkingGroupsLeadFormProps = FormikProps<FormValues> & FormAdditionalProps;
+type FormAdditionalProps = {}; // Aditional props coming all the way from export comonent into the inner form.
+type ExportComponentProps = ProposalFormExportProps<FormAdditionalProps, FormValues>;
+type FormContainerProps = ProposalFormContainerProps<ExportComponentProps>;
+type FormInnerProps = ProposalFormInnerProps<FormContainerProps, FormValues>;
 
-const SetContentWorkingGroupsLeadForm: React.FunctionComponent<SetContentWorkingGroupsLeadFormProps> = props => {
-  const { handleChange, members, errors, touched, values } = props;
+const SetContentWorkingGroupsLeadForm: React.FunctionComponent<FormInnerProps> = props => {
+  const { handleChange, errors, touched, values } = props;
   const errorLabelsProps = getFormErrorLabelsProps<FormValues>(errors, touched);
+  const membersOptions = [{
+    key: "Alice",
+    text: "Alice",
+    value: "207:5GrwvaEF5zXb26Fz9rcQpDWS57CtERHpNehXCPcNoHGKutQY",
+    image: { avatar: true, src: "https://react.semantic-ui.com/images/avatar/small/jenny.jpg" },
+  }]; // TODO: Fetch real members!
+
   return (
-    <GenericProposalForm {...props}>
+    <GenericProposalForm
+      {...props}
+      txMethod="createSetLeadProposal"
+      requiredStakePercent={0.25}
+      submitParams={[
+        props.myMemberId,
+        values.title,
+        values.rationale,
+        '{STAKE}',
+        values.workingGroupLead.split(':')
+      ]}
+    >
       <FormField
         error={errorLabelsProps.workingGroupLead}
         label="New Content Working Group Lead"
@@ -42,7 +63,7 @@ const SetContentWorkingGroupsLeadForm: React.FunctionComponent<SetContentWorking
           placeholder="Select a member"
           fluid
           selection
-          options={members}
+          options={membersOptions}
           onChange={handleChange}
           value={values.workingGroupLead}
         />
@@ -52,10 +73,8 @@ const SetContentWorkingGroupsLeadForm: React.FunctionComponent<SetContentWorking
   );
 }
 
-type OuterFormProps = DefaultOuterFormProps<FormAdditionalProps, FormValues>;
-
-export default withFormContainer<OuterFormProps, FormValues>({
-  mapPropsToValues: (props:OuterFormProps) => ({
+const FormContainer = withFormContainer<FormContainerProps, FormValues>({
+  mapPropsToValues: (props:FormContainerProps) => ({
     ...defaultValues,
     ...(props.initialData || {})
   }),
@@ -66,3 +85,5 @@ export default withFormContainer<OuterFormProps, FormValues>({
   handleSubmit: genericFormDefaultOptions.handleSubmit,
   displayName: "SetContentWorkingGroupLeadForm"
 })(SetContentWorkingGroupsLeadForm);
+
+export default withProposalFormData<FormContainerProps, ExportComponentProps>(FormContainer);

--- a/packages/joy-proposals/src/forms/SetContentWorkingGroupMintCapForm.tsx
+++ b/packages/joy-proposals/src/forms/SetContentWorkingGroupMintCapForm.tsx
@@ -1,11 +1,12 @@
 import React from 'react';
 import { default as MintCapacityForm } from './MintCapacityForm';
-import { genericFormDefaultOptions } from './GenericProposalForm';
+import { RouteComponentProps } from 'react-router';
 
-const ContentWorkingGroupMintCapForm = () => (
+const ContentWorkingGroupMintCapForm = (props: RouteComponentProps) => (
     <MintCapacityForm
       mintCapacityGroup="Content Working Group"
-      handleSubmit={ genericFormDefaultOptions.handleSubmit }/>
+      txMethod="createSetContentWorkingGroupMintCapacityProposal"
+      {...props} />
 );
 
 export default ContentWorkingGroupMintCapForm;

--- a/packages/joy-proposals/src/forms/SetCouncilMintCapForm.tsx
+++ b/packages/joy-proposals/src/forms/SetCouncilMintCapForm.tsx
@@ -1,11 +1,12 @@
 import React from 'react';
 import { default as MintCapacityForm } from './MintCapacityForm';
-import { genericFormDefaultOptions } from './GenericProposalForm';
+import { RouteComponentProps } from 'react-router';
 
-const CouncilMintCapForm = () => (
+const CouncilMintCapForm = (props: RouteComponentProps) => (
     <MintCapacityForm
       mintCapacityGroup="Council"
-      handleSubmit={ genericFormDefaultOptions.handleSubmit }/>
+      txMethod="createSetContentWorkingGroupMintCapacityProposal"
+      {...props} />
 );
 
 export default CouncilMintCapForm;

--- a/packages/joy-proposals/src/forms/SetMaxValidatorCountForm.tsx
+++ b/packages/joy-proposals/src/forms/SetMaxValidatorCountForm.tsx
@@ -1,13 +1,15 @@
 import React from "react";
-import { FormikProps } from "formik";
 import { getFormErrorLabelsProps } from "./errorHandling";
 import * as Yup from "yup";
 import {
   GenericProposalForm,
   GenericFormValues,
   genericFormDefaultOptions,
-  DefaultOuterFormProps,
-  genericFormDefaultValues
+  genericFormDefaultValues,
+  withProposalFormData,
+  ProposalFormExportProps,
+  ProposalFormContainerProps,
+  ProposalFormInnerProps
 } from './GenericProposalForm';
 import { InputFormField } from './FormFields';
 import { withFormContainer } from "./FormContainer";
@@ -22,14 +24,27 @@ const defaultValues: FormValues = {
   maxValidatorCount: ''
 }
 
-type FromAdditionalProps = {};
-type SetMaxValidatorCountFormProps = FormikProps<FormValues> & FromAdditionalProps;
+type FormAdditionalProps = {}; // Aditional props coming all the way from export comonent into the inner form.
+type ExportComponentProps = ProposalFormExportProps<FormAdditionalProps, FormValues>;
+type FormContainerProps = ProposalFormContainerProps<ExportComponentProps>;
+type FormInnerProps = ProposalFormInnerProps<FormContainerProps, FormValues>;
 
-const SetMaxValidatorCountForm: React.FunctionComponent<SetMaxValidatorCountFormProps> = props => {
+const SetMaxValidatorCountForm: React.FunctionComponent<FormInnerProps> = props => {
   const { handleChange, errors, touched, values } = props;
   const errorLabelsProps = getFormErrorLabelsProps<FormValues>(errors, touched);
   return (
-    <GenericProposalForm {...props}>
+    <GenericProposalForm
+      {...props}
+      txMethod="createSetValidatorCountProposal"
+      requiredStakePercent={0.25}
+      submitParams={[
+        props.myMemberId,
+        values.title,
+        values.rationale,
+        '{STAKE}',
+        values.maxValidatorCount
+      ]}
+    >
       <InputFormField
         error={errorLabelsProps.maxValidatorCount}
         label="Max Validator Count"
@@ -43,10 +58,8 @@ const SetMaxValidatorCountForm: React.FunctionComponent<SetMaxValidatorCountForm
   );
 }
 
-type OuterFormProps = DefaultOuterFormProps<FromAdditionalProps, FormValues>;
-
-export default withFormContainer<OuterFormProps, FormValues>({
-  mapPropsToValues: (props:OuterFormProps) => ({
+const FormContainer = withFormContainer<FormContainerProps, FormValues>({
+  mapPropsToValues: (props:FormContainerProps) => ({
     ...defaultValues,
     ...(props.initialData || {})
   }),
@@ -57,3 +70,5 @@ export default withFormContainer<OuterFormProps, FormValues>({
   handleSubmit: genericFormDefaultOptions.handleSubmit,
   displayName: "SetMaxValidatorCountForm"
 })(SetMaxValidatorCountForm);
+
+export default withProposalFormData<FormContainerProps, ExportComponentProps>(FormContainer);

--- a/packages/joy-proposals/src/forms/SetStorageRoleParamsForm.tsx
+++ b/packages/joy-proposals/src/forms/SetStorageRoleParamsForm.tsx
@@ -1,5 +1,4 @@
 import React from "react";
-import { FormikProps } from "formik";
 import { Form, Divider } from "semantic-ui-react";
 import { getFormErrorLabelsProps } from "./errorHandling";
 import * as Yup from "yup";
@@ -7,84 +6,229 @@ import {
   GenericProposalForm,
   GenericFormValues,
   genericFormDefaultOptions,
-  DefaultOuterFormProps,
-  genericFormDefaultValues
+  genericFormDefaultValues,
+  withProposalFormData,
+  ProposalFormExportProps,
+  ProposalFormContainerProps,
+  ProposalFormInnerProps
 } from "./GenericProposalForm";
 import { InputFormField } from "./FormFields";
 import { withFormContainer } from "./FormContainer";
+import { BlockNumber, Balance } from '@polkadot/types/interfaces';
+import { u32 } from "@polkadot/types/primitive";
+import { createType } from '@polkadot/types';
 import "./forms.css";
+
+// Move to joy-types?
+type RoleParameters = {
+  min_stake:  Balance,
+  min_actors: u32,
+  max_actors: u32,
+  reward: Balance,
+  reward_period: BlockNumber,
+  bonding_period: BlockNumber,
+  unbonding_period: BlockNumber,
+  min_service_period: BlockNumber,
+  startup_grace_period: BlockNumber,
+  entry_request_fee: Balance
+};
 
 // All of those are strings, because that's how those values are beeing passed from inputs
 type FormValues = GenericFormValues & {
-  storageProviderCount: string;
-  storageProviderReward: string;
-  storageProviderStakingLimit: string;
+  [K in keyof RoleParameters]: string
 };
 
 const defaultValues: FormValues = {
   ...genericFormDefaultValues,
-  storageProviderCount: "",
-  storageProviderReward: "",
-  storageProviderStakingLimit: ""
+  min_stake:  "",
+  min_actors: "",
+  max_actors: "",
+  reward: "",
+  reward_period: "",
+  bonding_period: "",
+  unbonding_period: "",
+  min_service_period: "",
+  startup_grace_period: "",
+  entry_request_fee: "",
 };
 
-type FormAdditionalProps = {};
-type SetStorageRoleParamsFormProps = FormikProps<FormValues> & FormAdditionalProps;
+type FormAdditionalProps = {}; // Aditional props coming all the way from export comonent into the inner form.
+type ExportComponentProps = ProposalFormExportProps<FormAdditionalProps, FormValues>;
+type FormContainerProps = ProposalFormContainerProps<ExportComponentProps>;
+type FormInnerProps = ProposalFormInnerProps<FormContainerProps, FormValues>;
 
-const SetStorageRoleParamsForm: React.FunctionComponent<SetStorageRoleParamsFormProps> = props => {
+function createRoleParameters(values: FormValues): RoleParameters {
+  return {
+    min_stake:  createType('Balance', values.min_stake),
+    min_actors: createType('u32', values.min_actors),
+    max_actors: createType('u32', values.max_actors),
+    reward: createType('Balance', values.reward),
+    reward_period: createType('BlockNumber', values.reward_period),
+    bonding_period: createType('BlockNumber', values.bonding_period),
+    unbonding_period: createType('BlockNumber', values.unbonding_period),
+    min_service_period: createType('BlockNumber', values.min_service_period),
+    startup_grace_period: createType('BlockNumber', values.startup_grace_period),
+    entry_request_fee: createType('Balance', values.entry_request_fee)
+  };
+}
+
+const SetStorageRoleParamsForm: React.FunctionComponent<FormInnerProps> = props => {
   const { handleChange, errors, touched, values } = props;
   const errorLabelsProps = getFormErrorLabelsProps<FormValues>(errors, touched);
   return (
-    <GenericProposalForm {...props}>
+    <GenericProposalForm
+      {...props}
+      txMethod="createSetStorageRoleParametersProposal"
+      requiredStakePercent={0.25}
+      submitParams={[
+        props.myMemberId,
+        values.title,
+        values.rationale,
+        '{STAKE}',
+        createRoleParameters(values)
+      ]}
+    >
       <Divider horizontal>Parameters</Divider>
-      <Form.Group widths="equal" style={{ marginBottom: "8rem" }}>
+      <Form.Group widths="equal" style={{ marginBottom: "2em" }}>
         <InputFormField
-          label="Providers Count"
-          help="The proposed maximum number of active Storage Providers"
+          label="Min. actors"
+          help="Minimum number of actors in this role"
           onChange={handleChange}
-          name="storageProviderCount"
+          name="min_actors"
+          placeholder="5"
+          error={errorLabelsProps.min_actors}
+          value={values.min_actors}
+        />
+        <InputFormField
+          label="Max. actors"
+          help="Maximum number of actors in this role"
+          fluid
+          onChange={handleChange}
+          name="max_actors"
+          placeholder="20"
+          error={errorLabelsProps.max_actors}
+          value={values.max_actors}
+        />
+      </Form.Group>
+      <Form.Group widths="equal" style={{ marginBottom: "2em" }}>
+        <InputFormField
+          label="Reward"
+          help="Reward for performing this role (for each period)"
+          fluid
+          onChange={handleChange}
+          name="reward"
           placeholder="10"
-          error={errorLabelsProps.storageProviderCount}
-          value={values.storageProviderCount}
+          error={errorLabelsProps.reward}
+          value={values.reward}
+          unit="tJOY"
         />
         <InputFormField
-          label="Provider Reward"
-          help="The proposed reward for Storage Providers (every x blocks)"
+          label="Reward period"
+          help="Reward period in blocks"
+          fluid
           onChange={handleChange}
-          name="storageProviderReward"
-          placeholder="50"
-          error={errorLabelsProps.storageProviderReward}
-          unit={"tJOY"}
-          value={values.storageProviderReward}
+          name="reward_period"
+          placeholder="600"
+          error={errorLabelsProps.reward_period}
+          value={values.reward_period}
+          unit="blocks"
+        />
+      </Form.Group>
+      <Form.Group widths="equal" style={{ marginBottom: "2em" }}>
+        <InputFormField
+          label="Min. stake"
+          help="Minimum stake for this role"
+          onChange={handleChange}
+          name="min_stake"
+          placeholder="3000"
+          error={errorLabelsProps.min_stake}
+          value={values.min_stake}
+          unit="tJOY"
         />
         <InputFormField
-          label="Staking Limit"
-          help="The minimum stake for Storage Providers"
+          label="Min. service period"
+          help="Minimum period of service in blocks"
+          fluid
           onChange={handleChange}
-          name="storageProviderStakingLimit"
-          placeholder="1500"
-          error={errorLabelsProps.storageProviderStakingLimit}
-          unit={"tJOY"}
-          value={values.storageProviderStakingLimit}
+          name="min_service_period"
+          placeholder="600"
+          error={errorLabelsProps.min_service_period}
+          value={values.min_service_period}
+          unit="blocks"
+        />
+      </Form.Group>
+      <Form.Group widths="equal" style={{ marginBottom: "2em" }}>
+        <InputFormField
+          label="Bonding period"
+          help="Bonding period in blocks"
+          fluid
+          onChange={handleChange}
+          name="bonding_period"
+          placeholder="600"
+          error={errorLabelsProps.bonding_period}
+          value={values.bonding_period}
+          unit="blocks"
+        />
+        <InputFormField
+          label="Unbounding period"
+          help="Unbounding period in blocks"
+          fluid
+          onChange={handleChange}
+          name="unbonding_period"
+          placeholder="600"
+          error={errorLabelsProps.unbonding_period}
+          value={values.unbonding_period}
+          unit="blocks"
+        />
+      </Form.Group>
+      <Form.Group widths="equal" style={{ marginBottom: "2em" }}>
+        <InputFormField
+          label="Startup grace period"
+          help="Startup grace period in blocks"
+          fluid
+          onChange={handleChange}
+          name="startup_grace_period"
+          placeholder="600"
+          error={errorLabelsProps.startup_grace_period}
+          value={values.startup_grace_period}
+          unit="blocks"
+        />
+        <InputFormField
+          label="Entry request fee"
+          help="Entry request fee"
+          fluid
+          onChange={handleChange}
+          name="entry_request_fee"
+          placeholder="100"
+          error={errorLabelsProps.entry_request_fee}
+          value={values.entry_request_fee}
+          unit="tJOY"
         />
       </Form.Group>
     </GenericProposalForm>
   );
 };
 
-type OuterFormProps = DefaultOuterFormProps<FormAdditionalProps, FormValues>;
-
-export default withFormContainer<OuterFormProps, FormValues>({
-  mapPropsToValues: (props: OuterFormProps) => ({
+const FormContainer = withFormContainer<FormContainerProps, FormValues>({
+  mapPropsToValues: (props: FormContainerProps) => ({
     ...defaultValues,
     ...(props.initialData || {})
   }),
   validationSchema: Yup.object().shape({
     ...genericFormDefaultOptions.validationSchema,
-    storageProviderCount: Yup.number().required("Enter the provider count"),
-    storageProviderReward: Yup.number().required("Enter the reward"),
-    storageProviderStakingLimit: Yup.number().required("Enter the provider staking limit")
+    min_stake: Yup.number().required("All parameters are required"),
+    min_actors: Yup.number().required("All parameters are required"),
+    max_actors: Yup.number().required("All parameters are required"),
+    reward: Yup.number().required("All parameters are required"),
+    reward_period: Yup.number().required("All parameters are required"),
+    bonding_period: Yup.number().required("All parameters are required"),
+    unbonding_period: Yup.number().required("All parameters are required"),
+    min_service_period: Yup.number().required("All parameters are required"),
+    startup_grace_period: Yup.number().required("All parameters are required"),
+    entry_request_fee: Yup.number().required("All parameters are required"),
   }),
   handleSubmit: genericFormDefaultOptions.handleSubmit,
   displayName: "SetStorageRoleParamsForm"
 })(SetStorageRoleParamsForm);
+
+export default withProposalFormData(FormContainer);

--- a/packages/joy-proposals/src/index.tsx
+++ b/packages/joy-proposals/src/index.tsx
@@ -3,12 +3,23 @@ import { Route, Switch } from "react-router";
 
 import { AppProps, I18nProps } from "@polkadot/react-components/types";
 import Tabs, { TabItem } from "@polkadot/react-components/Tabs";
-import { ApiProps } from "@polkadot/react-api/types";
 
 import "./index.css";
 
 import translate from "./translate";
 import NotDone from "./NotDone";
+import {
+  SignalForm,
+  EvictStorageProviderForm,
+  SpendingProposalForm,
+  SetContentWorkingGroupLeadForm,
+  SetContentWorkingGroupMintCapForm,
+  SetCouncilMintCapForm,
+  SetCouncilParamsForm,
+  SetStorageRoleParamsForm,
+  SetMaxValidatorCountForm,
+  RuntimeUpgradeForm
+} from "./forms";
 
 interface Props extends AppProps, I18nProps {}
 
@@ -37,6 +48,16 @@ function App(props: Props): React.ReactElement<Props> {
         <Route path={`${basePath}/new`} component={NotDone} />
         <Route path={`${basePath}/active`} component={NotDone} />
         <Route path={`${basePath}/finalized`} component={NotDone} />
+        <Route path={`${basePath}/create/signal`} component={SignalForm} />
+        <Route path={`${basePath}/create/evict-storage-provider`} component={EvictStorageProviderForm} />
+        <Route path={`${basePath}/create/spending`} component={SpendingProposalForm} />
+        <Route path={`${basePath}/create/set-cwg-lead`} component={SetContentWorkingGroupLeadForm} />
+        <Route path={`${basePath}/create/set-cwg-mint-cap`} component={SetContentWorkingGroupMintCapForm} />
+        <Route path={`${basePath}/create/set-council-mint-cap`} component={SetCouncilMintCapForm} />
+        <Route path={`${basePath}/create/set-election-params`} component={SetCouncilParamsForm} />
+        <Route path={`${basePath}/create/set-storage-role-params`} component={SetStorageRoleParamsForm} />
+        <Route path={`${basePath}/create/set-max-validator-count`} component={SetMaxValidatorCountForm} />
+        <Route path={`${basePath}/create/runtime-upgrade`} component={RuntimeUpgradeForm} />
         <Route path={`${basePath}/:id`} component={NotDone} />
         <Route component={NotDone} />
       </Switch>

--- a/packages/joy-proposals/src/index.tsx
+++ b/packages/joy-proposals/src/index.tsx
@@ -45,19 +45,19 @@ function App(props: Props): React.ReactElement<Props> {
         <Tabs basePath={basePath} items={tabs} />
       </header>
       <Switch>
-        <Route path={`${basePath}/new`} component={NotDone} />
         <Route path={`${basePath}/active`} component={NotDone} />
         <Route path={`${basePath}/finalized`} component={NotDone} />
-        <Route path={`${basePath}/create/signal`} component={SignalForm} />
-        <Route path={`${basePath}/create/evict-storage-provider`} component={EvictStorageProviderForm} />
-        <Route path={`${basePath}/create/spending`} component={SpendingProposalForm} />
-        <Route path={`${basePath}/create/set-cwg-lead`} component={SetContentWorkingGroupLeadForm} />
-        <Route path={`${basePath}/create/set-cwg-mint-cap`} component={SetContentWorkingGroupMintCapForm} />
-        <Route path={`${basePath}/create/set-council-mint-cap`} component={SetCouncilMintCapForm} />
-        <Route path={`${basePath}/create/set-election-params`} component={SetCouncilParamsForm} />
-        <Route path={`${basePath}/create/set-storage-role-params`} component={SetStorageRoleParamsForm} />
-        <Route path={`${basePath}/create/set-max-validator-count`} component={SetMaxValidatorCountForm} />
-        <Route path={`${basePath}/create/runtime-upgrade`} component={RuntimeUpgradeForm} />
+        <Route path={`${basePath}/new/signal`} component={SignalForm} />
+        <Route path={`${basePath}/new/evict-storage-provider`} component={EvictStorageProviderForm} />
+        <Route path={`${basePath}/new/spending`} component={SpendingProposalForm} />
+        <Route path={`${basePath}/new/set-cwg-lead`} component={SetContentWorkingGroupLeadForm} />
+        <Route path={`${basePath}/new/set-cwg-mint-cap`} component={SetContentWorkingGroupMintCapForm} />
+        <Route path={`${basePath}/new/set-council-mint-cap`} component={SetCouncilMintCapForm} />
+        <Route path={`${basePath}/new/set-election-params`} component={SetCouncilParamsForm} />
+        <Route path={`${basePath}/new/set-storage-role-params`} component={SetStorageRoleParamsForm} />
+        <Route path={`${basePath}/new/set-max-validator-count`} component={SetMaxValidatorCountForm} />
+        <Route path={`${basePath}/new/runtime-upgrade`} component={RuntimeUpgradeForm} />
+        <Route path={`${basePath}/new`} component={NotDone} />
         <Route path={`${basePath}/:id`} component={NotDone} />
         <Route component={NotDone} />
       </Switch>


### PR DESCRIPTION
This PR implements sending extrinsics by all existing proposal forms.

It also fixes the `SetStorageRoleParamsForm` (the parameters I used before were incomplete/incorrect) and introductes more correct props typing for proposal forms, all of which now "consist" of 3 components: inner form component, form container (`withFormContainer`) and the exported component (`withProposalFormData`, which adds `withOnlyMembers` etc.)

**TESTING**

New routes have been added to allow easy testing:
```
/proposals/create/signal
/proposals/create/evict-storage-provider
/proposals/create/spending
/proposals/create/set-cwg-lead
/proposals/create/set-cwg-mint-cap
/proposals/create/set-council-mint-cap
/proposals/create/set-election-params
/proposals/create/set-storage-role-params
/proposals/create/set-max-validator-count
/proposals/create/runtime-upgrade
```
Extrinsics should validate correctly if using parameters provided in placeholders (this mostly concerns forms like `SetCouncilParamsForm` and `SetStorageRoleParamsForm`)

**T.B.D. (not necessarily in this PR)**

`EvictStorageProviderForm`, `SpendingProposalForm` and `SetContentWorkingGroupLeadForm` are using mock data for the list of keys/memberships that the user can select (containing just dev node Alice key/membership). They need to have the correct data provided.