### PR TITLE
Fetch data for forms

### DIFF
--- a/packages/joy-proposals/src/forms/EvictStorageProviderForm.tsx
+++ b/packages/joy-proposals/src/forms/EvictStorageProviderForm.tsx
@@ -1,7 +1,7 @@
 import React from "react";
 import { getFormErrorLabelsProps } from "./errorHandling";
 import * as Yup from "yup";
-import { Label } from "semantic-ui-react";
+import { Label, Loader } from "semantic-ui-react";
 import {
   GenericProposalForm,
   GenericFormValues,
@@ -16,7 +16,9 @@ import { FormField } from "./FormFields";
 import { withFormContainer } from "./FormContainer";
 import { InputAddress } from '@polkadot/react-components/index';
 import { accountIdsToOptions } from "@polkadot/joy-election/utils";
-import { createType } from '@polkadot/types';
+import { AccountId } from "@polkadot/types/interfaces";
+import { useTransport } from "../runtime";
+import { usePromise } from "../utils";
 import "./forms.css";
 
 type FormValues = GenericFormValues & {
@@ -36,9 +38,9 @@ type FormInnerProps = ProposalFormInnerProps<FormContainerProps, FormValues>;
 const EvictStorageProviderForm: React.FunctionComponent<FormInnerProps> = props => {
   const { errors, touched, values, setFieldValue } = props;
   const errorLabelsProps = getFormErrorLabelsProps<FormValues>(errors, touched);
-  const storageProvidersOptions = accountIdsToOptions([
-    createType("AccountId", "5GrwvaEF5zXb26Fz9rcQpDWS57CtERHpNehXCPcNoHGKutQY") // Alice
-  ]); // TODO: Fetch real storage providers!
+  const transport = useTransport();
+  const [ storageProviders, error, loading ] = usePromise<AccountId[]>(() => transport.storageProviders(), []);
+  const storageProvidersOptions = accountIdsToOptions(storageProviders);
   return (
     <GenericProposalForm
       {...props}
@@ -52,21 +54,25 @@ const EvictStorageProviderForm: React.FunctionComponent<FormInnerProps> = props 
         values.storageProvider
       ]}
     >
-
-      <FormField
-        error={errorLabelsProps.storageProvider}
-        label="Storage provider"
-        help="The storage provider you propose to evict"
-      >
-        <InputAddress
-          onChange={(address) => setFieldValue("storageProvider", address) }
-          type="address"
-          placeholder="Select storage provider"
-          value={values.storageProvider}
-          options={storageProvidersOptions}
-        />
-        {errorLabelsProps.storageProvider && <Label {...errorLabelsProps.storageProvider} prompt />}
-      </FormField>
+      { loading ?
+        <><Loader active inline style={ { marginRight: '5px' } }/> Fetching storage providers...</>
+        : (
+          <FormField
+            error={errorLabelsProps.storageProvider}
+            label="Storage provider"
+            help="The storage provider you propose to evict"
+          >
+            <InputAddress
+              onChange={(address) => setFieldValue("storageProvider", address) }
+              type="address"
+              placeholder="Select storage provider"
+              value={values.storageProvider}
+              options={storageProvidersOptions}
+            />
+            {errorLabelsProps.storageProvider && <Label {...errorLabelsProps.storageProvider} prompt />}
+          </FormField>
+        )
+      }
     </GenericProposalForm>
   );
 };

--- a/packages/joy-proposals/src/forms/EvictStorageProviderForm.tsx
+++ b/packages/joy-proposals/src/forms/EvictStorageProviderForm.tsx
@@ -39,7 +39,7 @@ const EvictStorageProviderForm: React.FunctionComponent<FormInnerProps> = props 
   const { errors, touched, values, setFieldValue } = props;
   const errorLabelsProps = getFormErrorLabelsProps<FormValues>(errors, touched);
   const transport = useTransport();
-  const [ storageProviders, error, loading ] = usePromise<AccountId[]>(() => transport.storageProviders(), []);
+  const [ storageProviders, /* error */ , loading ] = usePromise<AccountId[]>(() => transport.storageProviders(), []);
   const storageProvidersOptions = accountIdsToOptions(storageProviders);
   return (
     <GenericProposalForm

--- a/packages/joy-proposals/src/forms/SetContentWorkingGroupLeadForm.tsx
+++ b/packages/joy-proposals/src/forms/SetContentWorkingGroupLeadForm.tsx
@@ -37,7 +37,7 @@ const SetContentWorkingGroupsLeadForm: React.FunctionComponent<FormInnerProps> =
   const { handleChange, errors, touched, values } = props;
   const errorLabelsProps = getFormErrorLabelsProps<FormValues>(errors, touched);
   const transport = useTransport();
-  const [ members, error, loading ] = usePromise<{ id: number, profile: Profile }[]>(() => transport.membersExceptCouncil(), []);
+  const [ members, /* error */, loading ] = usePromise<{ id: number, profile: Profile }[]>(() => transport.membersExceptCouncil(), []);
   const membersOptions = members.map(({ id, profile }) => ({
     key: profile.handle,
     text: profile.handle,

--- a/packages/joy-proposals/src/forms/SetContentWorkingGroupLeadForm.tsx
+++ b/packages/joy-proposals/src/forms/SetContentWorkingGroupLeadForm.tsx
@@ -1,5 +1,5 @@
 import React from "react";
-import { Dropdown, Label } from "semantic-ui-react";
+import { Dropdown, Label, Loader } from "semantic-ui-react";
 import { getFormErrorLabelsProps } from "./errorHandling";
 import * as Yup from "yup";
 import {
@@ -14,6 +14,9 @@ import {
 } from './GenericProposalForm';
 import { FormField } from './FormFields';
 import { withFormContainer } from "./FormContainer";
+import { useTransport } from "../runtime";
+import { usePromise } from "../utils";
+import { Profile } from "@joystream/types/members";
 import "./forms.css";
 
 type FormValues = GenericFormValues & {
@@ -33,13 +36,14 @@ type FormInnerProps = ProposalFormInnerProps<FormContainerProps, FormValues>;
 const SetContentWorkingGroupsLeadForm: React.FunctionComponent<FormInnerProps> = props => {
   const { handleChange, errors, touched, values } = props;
   const errorLabelsProps = getFormErrorLabelsProps<FormValues>(errors, touched);
-  const membersOptions = [{
-    key: "Alice",
-    text: "Alice",
-    value: "207:5GrwvaEF5zXb26Fz9rcQpDWS57CtERHpNehXCPcNoHGKutQY",
-    image: { avatar: true, src: "https://react.semantic-ui.com/images/avatar/small/jenny.jpg" },
-  }]; // TODO: Fetch real members!
-
+  const transport = useTransport();
+  const [ members, error, loading ] = usePromise<{ id: number, profile: Profile }[]>(() => transport.membersExceptCouncil(), []);
+  const membersOptions = members.map(({ id, profile }) => ({
+    key: profile.handle,
+    text: profile.handle,
+    value: `${id}:${ profile.root_account.toString() }`,
+    image: profile.avatar_uri.toString() ? { avatar: true, src: profile.avatar_uri }: null,
+  }));
   return (
     <GenericProposalForm
       {...props}
@@ -53,22 +57,27 @@ const SetContentWorkingGroupsLeadForm: React.FunctionComponent<FormInnerProps> =
         values.workingGroupLead.split(':')
       ]}
     >
-      <FormField
-        error={errorLabelsProps.workingGroupLead}
-        label="New Content Working Group Lead"
-        help="The member you propose to set as a new Content Working Group Lead">
-        <Dropdown
-          clearable
-          name="workingGroupLead"
-          placeholder="Select a member"
-          fluid
-          selection
-          options={membersOptions}
-          onChange={handleChange}
-          value={values.workingGroupLead}
-        />
-        {errorLabelsProps.workingGroupLead && <Label {...errorLabelsProps.workingGroupLead} prompt />}
-      </FormField>
+      { loading ?
+        <><Loader active inline style={ { marginRight: '5px' } }/> Fetching members...</>
+        : (
+          <FormField
+            error={errorLabelsProps.workingGroupLead}
+            label="New Content Working Group Lead"
+            help="The member you propose to set as a new Content Working Group Lead">
+            <Dropdown
+              clearable
+              search
+              name="workingGroupLead"
+              placeholder="Select a member"
+              fluid
+              selection
+              options={membersOptions}
+              onChange={handleChange}
+              value={values.workingGroupLead}
+            />
+            {errorLabelsProps.workingGroupLead && <Label {...errorLabelsProps.workingGroupLead} prompt />}
+          </FormField>
+        ) }
     </GenericProposalForm>
   );
 }

--- a/packages/joy-proposals/src/forms/SpendingProposalForm.tsx
+++ b/packages/joy-proposals/src/forms/SpendingProposalForm.tsx
@@ -15,8 +15,6 @@ import {
 import { InputFormField, FormField } from "./FormFields";
 import { withFormContainer } from "./FormContainer";
 import { InputAddress } from '@polkadot/react-components/index';
-import { accountIdsToOptions } from "@polkadot/joy-election/utils";
-import { createType } from '@polkadot/types';
 import "./forms.css";
 
 type FormValues = GenericFormValues & {
@@ -38,9 +36,6 @@ type FormInnerProps = ProposalFormInnerProps<FormContainerProps, FormValues>;
 const SpendingProposalForm: React.FunctionComponent<FormInnerProps> = props => {
   const { handleChange, errors, touched, values, setFieldValue } = props;
   const errorLabelsProps = getFormErrorLabelsProps<FormValues>(errors, touched);
-  const destinationAccountsOptions = accountIdsToOptions([
-    createType("AccountId", "5GrwvaEF5zXb26Fz9rcQpDWS57CtERHpNehXCPcNoHGKutQY") // Alice
-  ]); // TODO: Fetch real destination addresses!
   return (
     <GenericProposalForm
       {...props}
@@ -73,10 +68,9 @@ const SpendingProposalForm: React.FunctionComponent<FormInnerProps> = props => {
       >
         <InputAddress
           onChange={(address) => setFieldValue("destinationAccount", address) }
-          type="address"
+          type="all"
           placeholder="Select Destination Account"
           value={values.destinationAccount}
-          options={destinationAccountsOptions}
         />
         {errorLabelsProps.destinationAccount && <Label {...errorLabelsProps.destinationAccount} prompt />}
       </FormField>

--- a/packages/joy-proposals/src/forms/forms.css
+++ b/packages/joy-proposals/src/forms/forms.css
@@ -22,4 +22,8 @@
   .form-buttons {
     display: flex;
   }
+
+  .ui.dropdown .ui.avatar.image {
+    width: 2em !important;
+  }
 }


### PR DESCRIPTION
This PR implements fetching runtime data for the following forms:
-  `EvictStorageProvider` - list of current storage providers
-  `SetLead` - list of all members except council members

Besides that:
- Any address can now be selected/pasted in `SpendingProposalForm` as destination account
- I fixed minor visual glitch with avatar images displaying too wide in `Dropdown` form field