### PR TITLE
Vote kinds enum order fix

### DIFF
--- a/packages/joy-types/src/proposals.ts
+++ b/packages/joy-types/src/proposals.ts
@@ -206,7 +206,7 @@ export class ProposalStatus extends Enum {
 
 export class VoteKind extends Enum {
   constructor(value?: any, index?: number) {
-    super(["Abstain", "Approve", "Reject", "Slash"], value, index);
+    super(["Approve", "Reject", "Slash", "Abstain"], value, index);
   }
 }
 


### PR DESCRIPTION
This fixes the issue with proposal votes beeing incorrectly interpreted by Pioneer due to wrong order in `VoteKind` enum type