### PR TITLE
Proposal statuses fix

### DIFF
--- a/packages/joy-proposals/src/Proposal/Details.tsx
+++ b/packages/joy-proposals/src/Proposal/Details.tsx
@@ -14,7 +14,7 @@ export default function Details({
   extendedStatus
 }: DetailsProps) {
   const { type, createdAt, proposer } = proposal;
-  const { statusStr, substage, expiresIn } = extendedStatus;
+  const { displayStatus, periodStatus, expiresIn } = extendedStatus;
   return (
     <Item.Group className="details-container">
       <Item>
@@ -36,14 +36,14 @@ export default function Details({
       <Item>
         <Item.Content>
           <Item.Extra>Stage:</Item.Extra>
-          <Header as="h4">{ statusStr }</Header>
+          <Header as="h4">{ displayStatus }</Header>
         </Item.Content>
       </Item>
-      { (substage !== null) && (
+      { (periodStatus !== null) && (
         <Item>
           <Item.Content>
             <Item.Extra>Substage:</Item.Extra>
-            <Header as="h4">{ substage }</Header>
+            <Header as="h4">{ periodStatus }</Header>
           </Item.Content>
         </Item>
       ) }

--- a/packages/joy-proposals/src/Proposal/ProposalDetails.tsx
+++ b/packages/joy-proposals/src/Proposal/ProposalDetails.tsx
@@ -11,40 +11,59 @@ import { withCalls } from '@polkadot/react-api';
 import { withMulti } from '@polkadot/react-api/with';
 
 import "./Proposal.css";
-import { ProposalId } from "@joystream/types/proposals";
+import { ProposalId, ProposalDecisionStatuses, ApprovedProposalStatuses } from "@joystream/types/proposals";
 import { BlockNumber } from '@polkadot/types/interfaces'
 import { MemberId } from "@joystream/types/members";
 import { Seat } from "@joystream/types/";
 
+type BasicProposalStatus = 'Active' | 'Finalized';
+type ProposalPeriodStatus = 'Voting period' | 'Grace period';
+type ProposalDisplayStatus = BasicProposalStatus | ProposalDecisionStatuses | ApprovedProposalStatuses;
+
 export type ExtendedProposalStatus = {
-  statusStr: string, // TODO: Active / Finalized?
-  substage: 'Voting period' | 'Grace period' | null,
+  displayStatus: ProposalDisplayStatus,
+  periodStatus: ProposalPeriodStatus | null,
   expiresIn: number | null,
 }
 
 export function getExtendedStatus(proposal: ParsedProposal, bestNumber: BlockNumber | undefined): ExtendedProposalStatus {
-  const statusStr = Object.keys(proposal.status)[0];
-  const isActive = statusStr === 'Active';
-  const { votingPeriod, gracePeriod } = proposal.parameters;
+  const basicStatus = Object.keys(proposal.status)[0] as BasicProposalStatus;
+  let expiresIn: number | null = null;
 
-  const blockAge = bestNumber ? (bestNumber.toNumber() - proposal.createdAtBlock) : 0;
-  const substage =
-    (
-      isActive && (
-      votingPeriod - blockAge  > 0 ?
-        'Voting period'
-        : 'Grace period'
-      )
-    ) || null;
-  const expiresIn = substage && (
-    substage === 'Voting period' ?
-      votingPeriod - blockAge
-      : (gracePeriod + votingPeriod) - blockAge
-  )
+  let displayStatus: ProposalDisplayStatus = basicStatus;
+  let periodStatus: ProposalPeriodStatus | null = null;
+
+  if (!bestNumber) return { displayStatus, periodStatus, expiresIn };
+
+  const { votingPeriod, gracePeriod } = proposal.parameters;
+  const blockAge = bestNumber.toNumber() - proposal.createdAtBlock;
+
+  if (basicStatus === 'Active') {
+    expiresIn = Math.max(votingPeriod - blockAge, 0) || null;
+    if (expiresIn) periodStatus = 'Voting period';
+  }
+
+  if (basicStatus === 'Finalized') {
+    const { finalizedAt, proposalStatus } = proposal.status['Finalized'];
+
+    const decisionStatus: ProposalDecisionStatuses = Object.keys(proposalStatus)[0] as ProposalDecisionStatuses;
+    displayStatus = decisionStatus;
+    if (decisionStatus === 'Approved') {
+      const approvedStatus: ApprovedProposalStatuses = Object.keys(proposalStatus["Approved"])[0] as ApprovedProposalStatuses;
+      if (approvedStatus === 'PendingExecution') {
+        const finalizedAge = bestNumber.toNumber() - finalizedAt;
+        expiresIn = Math.max(gracePeriod - finalizedAge, 0) || null;
+        if (expiresIn) periodStatus = 'Grace period';
+      }
+      else {
+        displayStatus = approvedStatus; // Executed / ExecutionFailed
+      }
+    }
+  }
 
   return {
-    statusStr,
-    substage,
+    displayStatus,
+    periodStatus,
     expiresIn
   }
 }
@@ -73,7 +92,7 @@ function ProposalDetails({ proposal, proposalId, myAddress, myMemberId, iAmMembe
         <VotingSection
           proposalId={proposalId}
           memberId={ myMemberId as MemberId }
-          isVotingPeriod={ extendedStatus.substage === 'Voting period' }/>
+          isVotingPeriod={ extendedStatus.periodStatus === 'Voting period' }/>
       ) }
       <Votes proposalId={proposalId} />
     </Container>

--- a/packages/joy-types/src/proposals.ts
+++ b/packages/joy-types/src/proposals.ts
@@ -1,4 +1,4 @@
-import { Text, u32, Enum, getTypeRegistry, Tuple, GenericAccountId, u8, Vec, Option, Struct } from "@polkadot/types";
+import { Text, u32, Enum, getTypeRegistry, Tuple, GenericAccountId, u8, Vec, Option, Struct, Null } from "@polkadot/types";
 import { BlockNumber, Balance } from "@polkadot/types/interfaces";
 import { MemberId } from "./members";
 import { StakeId } from "./stake";
@@ -159,11 +159,44 @@ export class ActiveStake extends JoyStruct<IActiveStake> {
   }
 }
 
+export class ExecutionFailedStatus extends Struct {
+  constructor(value?: any) {
+    super(
+      {
+        error: "Vec<u8>",
+      },
+      value
+    );
+  }
+}
+
+class ExecutionFailed extends ExecutionFailedStatus {}
+
+export type ApprovedProposalStatuses = "PendingExecution" | "Executed" | "ExecutionFailed";
+
+export class ApprovedProposalStatus extends Enum {
+  constructor(value?: any, index?: number) {
+    super({
+      PendingExecution: Null,
+      Executed: Null,
+      ExecutionFailed
+    }, value, index);
+  }
+}
+export class Approved extends ApprovedProposalStatus {};
+
 export type ProposalDecisionStatuses = "Canceled" | "Vetoed" | "Rejected" | "Slashed" | "Expired" | "Approved";
 
 export class ProposalDecisionStatus extends Enum {
   constructor(value?: any, index?: number) {
-    super(["Canceled", "Vetoed", "Rejected", "Slashed", "Expired", "Approved"], value, index);
+    super({
+      Canceled: Null,
+      Vetoed: Null,
+      Rejected: Null,
+      Slashed: Null,
+      Expired: Null,
+      Approved
+    }, value, index);
   }
 }
 


### PR DESCRIPTION
This PR fixes the logic of displaying proposal status and introduces important fix in `joy-types`.

**The `joy-types` issue:**

The incomplete definition of `ProposalDecisionStatus` caused many problems with parsing proposal data coming from the runtime, ie.:

- The information of `Approved` status was incomplete (no information about execution result etc.)
- Unreliable values in `votingResults` (most likely caused by bytes in `Proposal` struct beeing shifted due to lack of defined `ApprovedProposalStatus`)
- <s>Possibly also unreliable values in `createdAt` (for same reason as above. Not 100% sure about this one, but the creation dates seem to display correctly now after the fix)</s> (update: this problem still appears after some time, so it's probably related to something else)