### PR TITLE
Fix Council Tab crash

### DIFF
--- a/packages/joy-election/src/Council.tsx
+++ b/packages/joy-election/src/Council.tsx
@@ -1,63 +1,62 @@
-import React from 'react';
+import React from "react";
 
-import { ApiProps } from '@polkadot/react-api/types';
-import { I18nProps } from '@polkadot/react-components/types';
-import { withCalls } from '@polkadot/react-api/with';
-import { Table } from 'semantic-ui-react';
-import { formatBalance } from '@polkadot/util';
-import AddressMini from '@polkadot/react-components/AddressMiniJoy';
+import { ApiProps } from "@polkadot/react-api/types";
+import { I18nProps } from "@polkadot/react-components/types";
+import { withCalls } from "@polkadot/react-api/with";
+import { Table } from "semantic-ui-react";
+import { formatBalance } from "@polkadot/util";
+import AddressMini from "@polkadot/react-components/AddressMiniJoy";
 
-import { calcBackersStake } from '@polkadot/joy-utils/index';
-import { Seat } from '@joystream/types/';
-import translate from './translate';
-import Section from '@polkadot/joy-utils/Section';
+import { calcBackersStake } from "@polkadot/joy-utils/index";
+import { Seat } from "@joystream/types/";
+import translate from "./translate";
+import Section from "@polkadot/joy-utils/Section";
 
-type Props = ApiProps & I18nProps & {
-  council?: Seat[]
-};
+type Props = ApiProps &
+  I18nProps & {
+    council?: Seat[];
+  };
 
 type State = {};
 
 class Council extends React.PureComponent<Props, State> {
-
   state: State = {};
 
-  private renderTable (council: Seat[]) {
+  private renderTable(council: Seat[]) {
     return (
       <Table celled selectable compact>
-      <Table.Header>
-        <Table.Row>
-          <Table.HeaderCell>#</Table.HeaderCell>
-          <Table.HeaderCell>Council member</Table.HeaderCell>
-          <Table.HeaderCell>Own stake</Table.HeaderCell>
-          <Table.HeaderCell>Backers' stake</Table.HeaderCell>
-          <Table.HeaderCell>Backers count</Table.HeaderCell>
-        </Table.Row>
-      </Table.Header>
-      <Table.Body>{council.map((seat, index) => (
-        <Table.Row key={index}>
-          <Table.Cell>{index + 1}</Table.Cell>
-          <Table.Cell>
-            <AddressMini value={seat.member} isShort={false} isPadded={false} withBalance={true} />
-          </Table.Cell>
-          <Table.Cell>{formatBalance(seat.stake)}</Table.Cell>
-          <Table.Cell>{formatBalance(calcBackersStake(seat.backers))}</Table.Cell>
-          <Table.Cell>{seat.backers.length}</Table.Cell>
-        </Table.Row>
-      ))}</Table.Body>
+        <Table.Header>
+          <Table.Row>
+            <Table.HeaderCell>#</Table.HeaderCell>
+            <Table.HeaderCell>Council member</Table.HeaderCell>
+            <Table.HeaderCell>Own stake</Table.HeaderCell>
+            <Table.HeaderCell>Backers&apos stake</Table.HeaderCell>
+            <Table.HeaderCell>Backers count</Table.HeaderCell>
+          </Table.Row>
+        </Table.Header>
+        <Table.Body>
+          {council.map((seat, index) => (
+            <Table.Row key={index}>
+              <Table.Cell>{index + 1}</Table.Cell>
+              <Table.Cell>
+                <AddressMini value={seat.member} isShort={false} isPadded={false} withBalance={true} />
+              </Table.Cell>
+              <Table.Cell>{formatBalance(seat.stake)}</Table.Cell>
+              <Table.Cell>{formatBalance(calcBackersStake(seat.backers))}</Table.Cell>
+              <Table.Cell>{seat.backers.length}</Table.Cell>
+            </Table.Row>
+          ))}
+        </Table.Body>
       </Table>
     );
   }
 
-  render () {
+  render() {
     const { council = [] } = this.props;
     // console.log({ council });
     return (
-      <Section title='Active council members'>
-      {!council.length
-          ? <em>Council is not elected yet</em>
-          : this.renderTable(council)
-      }
+      <Section title="Active council members">
+        {!council.length ? <em>Council is not elected yet</em> : this.renderTable(council)}
       </Section>
     );
   }
@@ -65,7 +64,5 @@ class Council extends React.PureComponent<Props, State> {
 
 // inject the actual API calls automatically into props
 export default translate(
-  withCalls<Props>(
-    ['query.council.activeCouncil', { propName: 'council' }]
-  )(Council)
+  withCalls<Props>(["query.council.activeCouncil", { propName: "council" }])(Council)
 );

--- a/packages/joy-election/src/Council.tsx
+++ b/packages/joy-election/src/Council.tsx
@@ -30,7 +30,7 @@ class Council extends React.PureComponent<Props, State> {
             <Table.HeaderCell>#</Table.HeaderCell>
             <Table.HeaderCell>Council member</Table.HeaderCell>
             <Table.HeaderCell>Own stake</Table.HeaderCell>
-            <Table.HeaderCell>Backers&apos stake</Table.HeaderCell>
+            <Table.HeaderCell>Backers' stake</Table.HeaderCell>
             <Table.HeaderCell>Backers count</Table.HeaderCell>
           </Table.Row>
         </Table.Header>

--- a/packages/joy-types/src/proposals.ts
+++ b/packages/joy-types/src/proposals.ts
@@ -82,38 +82,38 @@ class ProposalParameters extends Struct {
     );
   }
 
-        // During this period, votes can be accepted
+  // During this period, votes can be accepted
   get votingPeriod(): BlockNumber {
     return this.get("votingPeriod") as BlockNumber;
   }
 
-        /* A pause before execution of the approved proposal. Zero means approved proposal would be
+  /* A pause before execution of the approved proposal. Zero means approved proposal would be
      executed immediately. */
   get gracePeriod(): BlockNumber {
     return this.get("gracePeriod") as BlockNumber;
   }
 
-        // Quorum percentage of approving voters required to pass the proposal.
+  // Quorum percentage of approving voters required to pass the proposal.
   get approvalQuorumPercentage(): u32 {
     return this.get("approvalQuorumPercentage") as u32;
   }
 
-        // Approval votes percentage threshold to pass the proposal.
+  // Approval votes percentage threshold to pass the proposal.
   get approvalThresholdPercentage(): u32 {
     return this.get("approvalThresholdPercentage") as u32;
   }
 
-        // Quorum percentage of voters required to slash the proposal.
+  // Quorum percentage of voters required to slash the proposal.
   get slashingQuorumPercentage(): u32 {
     return this.get("slashingQuorumPercentage") as u32;
   }
 
-        // Slashing votes percentage threshold to slash the proposal.
+  // Slashing votes percentage threshold to slash the proposal.
   get slashingThresholdPercentage(): u32 {
     return this.get("slashingThresholdPercentage") as u32;
   }
 
-        // Proposal stake
+  // Proposal stake
   get requiredStake(): Option<Balance> {
     return this.get("requiredStake") as Option<Balance>;
   }
@@ -324,7 +324,7 @@ export class Proposal extends Struct {
   }
 }
 
-export class Baker extends Struct {
+export class Backer extends Struct {
   constructor(value?: any) {
     super(
       {
@@ -334,14 +334,24 @@ export class Baker extends Struct {
       value
     );
   }
+
+  get member(): MemberId {
+    return this.get("member") as MemberId;
+  }
+
+  get stake(): Balance {
+    return this.get("stake") as Balance;
+  }
 }
+
+export class Backers extends Vec.with(Backer) {}
 export class Seat extends Struct {
   constructor(value?: any) {
     super(
       {
         member: "AccountId",
         stake: "Balance",
-        backers: Vec.with(Baker)
+        backers: Backers
       },
       value
     );
@@ -349,6 +359,14 @@ export class Seat extends Struct {
 
   get member(): AccountId {
     return this.get("member") as AccountId;
+  }
+
+  get stake(): Balance {
+    return this.get("stake") as Balance;
+  }
+
+  get backers(): Backers {
+    return this.get("backers") as Backers;
   }
 }
 
@@ -367,7 +385,8 @@ export function registerProposalTypes() {
       VoteKind,
       Seat,
       Seats,
-      Baker
+      Backer,
+      Backers
     });
   } catch (err) {
     console.error("Failed to register custom types of proposals module", err);


### PR DESCRIPTION
This fixes the bug of the council tab crashing. 
It was due to `Backer` being misspelt to `Baker` in `joy-types`.