### PR TITLE
Improved proposal details data flow

### DIFF
--- a/packages/joy-proposals/src/Proposal/Body.tsx
+++ b/packages/joy-proposals/src/Proposal/Body.tsx
@@ -106,7 +106,7 @@ export default function Body({ type, title, description, params = [] }: BodyProp
         </Card.Header>
         <Card.Description>{description}</Card.Description>
         <Header as="h4">Parameters:</Header>
-        <Item.Group textAlign="left" relaxed>
+        <Item.Group style={{ textAlign: "left" }} relaxed>
           { Object.entries(parseParams(params)).map(([paramName, paramValue]) => (
             <ProposalParam key={paramName}>
               <ProposalParamName longestParamName={longestParamName}>{paramName}:</ProposalParamName>

--- a/packages/joy-proposals/src/Proposal/PromiseComponent.tsx
+++ b/packages/joy-proposals/src/Proposal/PromiseComponent.tsx
@@ -1,0 +1,20 @@
+import React from 'react';
+import Loading from "./Loading";
+import Error from "./Error";
+
+type PromiseComponentProps = {
+  loading: boolean,
+  error: any,
+  message: string,
+}
+const PromiseComponent: React.FunctionComponent<PromiseComponentProps> = ({ loading, error, message, children }) => {
+  if (loading && !error) {
+    return <Loading text={ message } />;
+  } else if (error) {
+    return <Error error={error} />;
+  }
+
+  return <>{ children }</>;
+}
+
+export default PromiseComponent;

--- a/packages/joy-proposals/src/Proposal/ProposalDetails.tsx
+++ b/packages/joy-proposals/src/Proposal/ProposalDetails.tsx
@@ -6,7 +6,7 @@ import Body from "./Body";
 import VotingSection from "./VotingSection";
 import Votes from "./Votes";
 import { MyAccountProps, withMyAccount } from "@polkadot/joy-utils/MyAccount"
-import { ParsedProposal } from "../runtime";
+import { ParsedProposal, ProposalVote } from "../runtime";
 import { withCalls } from '@polkadot/react-api';
 import { withMulti } from '@polkadot/react-api/with';
 
@@ -15,6 +15,7 @@ import { ProposalId, ProposalDecisionStatuses, ApprovedProposalStatuses } from "
 import { BlockNumber } from '@polkadot/types/interfaces'
 import { MemberId } from "@joystream/types/members";
 import { Seat } from "@joystream/types/";
+import PromiseComponent from './PromiseComponent';
 
 type BasicProposalStatus = 'Active' | 'Finalized';
 type ProposalPeriodStatus = 'Voting period' | 'Grace period';
@@ -72,11 +73,21 @@ export function getExtendedStatus(proposal: ParsedProposal, bestNumber: BlockNum
 type ProposalDetailsProps = MyAccountProps & {
   proposal: ParsedProposal,
   proposalId: ProposalId,
+  votesListState: { data: ProposalVote[], error: any, loading: boolean },
   bestNumber?: BlockNumber,
   council?: Seat[]
 };
 
-function ProposalDetails({ proposal, proposalId, myAddress, myMemberId, iAmMember, council, bestNumber }: ProposalDetailsProps) {
+function ProposalDetails({
+  proposal,
+  proposalId,
+  myAddress,
+  myMemberId,
+  iAmMember,
+  council,
+  bestNumber,
+  votesListState
+}: ProposalDetailsProps) {
   const iAmCouncilMember = iAmMember && council && council.some(seat => seat.member.toString() === myAddress);
   const extendedStatus = getExtendedStatus(proposal, bestNumber);
   return (
@@ -94,7 +105,12 @@ function ProposalDetails({ proposal, proposalId, myAddress, myMemberId, iAmMembe
           memberId={ myMemberId as MemberId }
           isVotingPeriod={ extendedStatus.periodStatus === 'Voting period' }/>
       ) }
-      <Votes proposalId={proposalId} />
+      <PromiseComponent
+        error={votesListState.error}
+        loading={votesListState.loading}
+        message="Fetching the votes...">
+        <Votes votes={votesListState.data} />
+      </PromiseComponent>
     </Container>
   );
 }

--- a/packages/joy-proposals/src/Proposal/ProposalFromId.tsx
+++ b/packages/joy-proposals/src/Proposal/ProposalFromId.tsx
@@ -1,11 +1,10 @@
 import React from "react";
 import { RouteComponentProps } from "react-router-dom";
-
 import ProposalDetails from "./ProposalDetails";
-import { useTransport, ParsedProposal } from "../runtime";
-import { usePromise } from "../utils";
+import { useProposalSubscription } from "../utils";
 import Error from "./Error";
 import Loading from "./Loading";
+
 
 export default function ProposalFromId(props: RouteComponentProps<any>) {
   const {
@@ -13,18 +12,14 @@ export default function ProposalFromId(props: RouteComponentProps<any>) {
       params: { id }
     }
   } = props;
-  const transport = useTransport();
 
-  const [proposal, error, loading] = usePromise<ParsedProposal>(
-    () => transport.proposalById(id),
-    {} as ParsedProposal
-  );
+  const { proposal: proposalState, votes: votesState } = useProposalSubscription(id);
 
-  if (loading && !error) {
+  if (proposalState.loading && !proposalState.error) {
     return <Loading text="Fetching Proposal..." />;
-  } else if (error) {
-    return <Error error={error} />;
+  } else if (proposalState.error) {
+    return <Error error={proposalState.error} />;
   }
 
-  return <ProposalDetails proposal={ proposal } proposalId={id}/>;
+  return <ProposalDetails proposal={ proposalState.data } proposalId={ id } votesListState={ votesState }/>;
 }

--- a/packages/joy-proposals/src/Proposal/Votes.tsx
+++ b/packages/joy-proposals/src/Proposal/Votes.tsx
@@ -2,27 +2,15 @@ import React from "react";
 import { IdentityIcon } from '@polkadot/react-components';
 import { Header, Divider, Table, Image, Icon } from "semantic-ui-react";
 import useVoteStyles from "./useVoteStyles";
-import { useTransport, ProposalVote } from "../runtime";
-import { ProposalId, VoteKind } from "@joystream/types/proposals";
+import { ProposalVote } from "../runtime";
+import { VoteKind } from "@joystream/types/proposals";
 import { VoteKindStr } from "./VotingSection";
-import { usePromise } from "../utils";
-import Loading from "./Loading";
-import Error from "./Error";
 
 type VotesProps = {
-  proposalId: ProposalId
+  votes: ProposalVote[]
 };
 
-export default function Votes({ proposalId }: VotesProps) {
-  const transport = useTransport();
-  const [votes, loading, error] = usePromise<ProposalVote[]>(() => transport.votes(proposalId), []);
-
-  if (loading && !error) {
-    return <Loading text="Fetching the votes..." />;
-  } else if (error) {
-    return <Error error={error} />;
-  }
-
+export default function Votes({ votes }: VotesProps) {
   const nonEmptyVotes = votes.filter(proposalVote => proposalVote.vote !== null);
 
   if (!nonEmptyVotes.length) {


### PR DESCRIPTION
This PR improves the data flow on `ProposalDetails` page, taking advantage of polkadot api subscriptions (see: https://polkadot.js.org/api/start/api.query.subs.html).

It introduces the reusable hook `useProposalSubscription`, which takes care of re-fetching the proposal (and votes) data from the transport each time there is a change in the proposal detected in the runtime. This means that the data on this page should always be in sync with the runtime (even when not the current user, but somebody else votes on the proposal).