### PR TITLE
ActiveStake.stakeId type bug fix

### DIFF
--- a/packages/joy-types/src/proposals.ts
+++ b/packages/joy-types/src/proposals.ts
@@ -151,7 +151,7 @@ export class ActiveStake extends JoyStruct<IActiveStake> {
   constructor(value?: IActiveStake) {
     super(
       {
-        stakeId: u32,
+        stakeId: StakeId,
         sourceAccountId: GenericAccountId
       },
       value


### PR DESCRIPTION
This PR fixes minor bug in `joy-types/proposals.ts` where the `stakeId` field of `ActiveStake` struct was defined as `u32` despite `StakeId` beeing actually `u64`.

This caused unreliable values in ie. `Proposal.votingResults`, similarly to how it was described here: https://github.com/Joystream/apps/pull/391 (but right now the issue is only regarding proposals during their Voting Period)