### PR TITLE
Cancellation fee: fetch from rutime

### DIFF
--- a/packages/joy-proposals/src/Proposal/Body.tsx
+++ b/packages/joy-proposals/src/Proposal/Body.tsx
@@ -140,7 +140,8 @@ export default function Body({
                 You can only cancel your proposal while it's still in the Voting Period.
               </p>
               <p style={{ margin: '0.5em 0', padding: '0' }}>
-                The cancellation fee for this type of proposal is: <b>{ cancellationFee || 'NONE' }</b>
+                The cancellation fee for this type of proposal is:&nbsp;
+                <b>{ cancellationFee ? `${ cancellationFee } tJOY` : 'NONE' }</b>
               </p>
               <Button.Group color="red">
                 <TxButton

--- a/packages/joy-proposals/src/Proposal/ProposalDetails.tsx
+++ b/packages/joy-proposals/src/Proposal/ProposalDetails.tsx
@@ -104,7 +104,7 @@ function ProposalDetails({
         proposalId={ proposalId }
         proposerId={ proposal.proposerId }
         isCancellable={ isVotingPeriod }
-        cancellationFee={ 0 } // TODO: We need to access it from the runtime!
+        cancellationFee={ proposal.cancellationFee }
         />
       { iAmCouncilMember && (
         <VotingSection

--- a/packages/joy-proposals/src/runtime/transport.ts
+++ b/packages/joy-proposals/src/runtime/transport.ts
@@ -49,6 +49,7 @@ export type ParsedProposal = {
     slashingThresholdPercentage: number;
     votingPeriod: number;
   };
+  cancellationFee: number;
 };
 
 export type ProposalVote = {

--- a/packages/joy-proposals/src/stories/data/ProposalDetails.mock.ts
+++ b/packages/joy-proposals/src/stories/data/ProposalDetails.mock.ts
@@ -45,7 +45,8 @@ const mockedProposal: ParsedProposal = {
     rejections: 1,
     slashes: 0
   },
-  createdAt: new Date("Mar 25, 2020 at 14:20")
+  createdAt: new Date("Mar 25, 2020 at 14:20"),
+  cancellationFee: 5
 };
 
 export default mockedProposal;


### PR DESCRIPTION
This PR adds real cancellation fee data (fetched from runtime through `api.consts`) on `ChooseProposalType` and `ProposalDetails` pages (based on this PR: https://github.com/Joystream/joystream/pull/385)