### PR TITLE
SetLead proposal details member profile preview

### DIFF
--- a/packages/joy-proposals/src/Proposal/Details.tsx
+++ b/packages/joy-proposals/src/Proposal/Details.tsx
@@ -8,9 +8,10 @@ import ProfilePreview from "./ProfilePreview";
 type DetailsProps = {
   proposal: ParsedProposal;
   extendedStatus: ExtendedProposalStatus;
+  proposerLink?: boolean;
 };
 
-export default function Details({ proposal, extendedStatus }: DetailsProps) {
+export default function Details({ proposal, extendedStatus, proposerLink = false }: DetailsProps) {
   const { type, createdAt, proposer } = proposal;
   const { displayStatus, periodStatus, expiresIn } = extendedStatus;
   return (
@@ -22,6 +23,7 @@ export default function Details({ proposal, extendedStatus }: DetailsProps) {
             avatar_uri={proposer.avatar_uri}
             root_account={proposer.root_account}
             handle={proposer.handle}
+            link={ proposerLink }
           />
           <Item.Extra>{createdAt.toLocaleString()}</Item.Extra>
         </Item.Content>

--- a/packages/joy-proposals/src/Proposal/ProfilePreview.tsx
+++ b/packages/joy-proposals/src/Proposal/ProfilePreview.tsx
@@ -1,15 +1,17 @@
 import React from "react";
 import { Image, Header } from "semantic-ui-react";
 import { IdentityIcon } from "@polkadot/react-components";
+import { Link } from "react-router-dom";
 
 type ProfileItemProps = {
   avatar_uri: string;
   root_account: string;
   handle: string;
+  link?: boolean;
 };
 
-export default function ProfilePreview({ avatar_uri, root_account, handle }: ProfileItemProps) {
-  return (
+export default function ProfilePreview({ avatar_uri, root_account, handle, link = false }: ProfileItemProps) {
+  const Preview = (
     <div className="details-profile">
       {avatar_uri ? (
         <Image src={avatar_uri} avatar floated="left" />
@@ -21,4 +23,10 @@ export default function ProfilePreview({ avatar_uri, root_account, handle }: Pro
       </Header>
     </div>
   );
+
+  if (link) {
+    return <Link to={ `/members/${ handle }` }>{ Preview }</Link>;
+  }
+
+  return Preview;
 }

--- a/packages/joy-proposals/src/Proposal/ProposalDetails.tsx
+++ b/packages/joy-proposals/src/Proposal/ProposalDetails.tsx
@@ -94,7 +94,7 @@ function ProposalDetails({
   const isVotingPeriod = extendedStatus.periodStatus === 'Voting period';
   return (
     <Container className="Proposal">
-      <Details proposal={proposal} extendedStatus={extendedStatus}/>
+      <Details proposal={proposal} extendedStatus={extendedStatus} proposerLink={ true }/>
       <Body
         type={ proposal.type }
         title={ proposal.title }

--- a/packages/joy-proposals/src/runtime/transport.substrate.ts
+++ b/packages/joy-proposals/src/runtime/transport.substrate.ts
@@ -72,7 +72,7 @@ export class SubstrateTransport extends Transport {
     return this.proposalsCodex.proposalDetailsByProposalId(id);
   }
 
-  memberProfile(id: MemberId): Promise<Option<Profile>> {
+  memberProfile(id: MemberId | number): Promise<Option<Profile>> {
     return this.members.memberProfile(id) as Promise<Option<Profile>>;
   }
 


### PR DESCRIPTION
This PR takes advantage of new `ProfilePreview` component to display member profile preview on `SetLead` proposal details page. It also adds to possibility to make the `ProfilePreview` link to member's full profile