### PR TITLE
Fix block hash query

### DIFF
--- a/packages/joy-proposals/src/runtime/transport.substrate.ts
+++ b/packages/joy-proposals/src/runtime/transport.substrate.ts
@@ -72,7 +72,8 @@ export class SubstrateTransport extends Transport {
   }
 
   async blockHash(height: number): Promise<string> {
-    const blockHash = await this.api.query.system.blockHash(height);
+    const blockHash = await this.api.rpc.chain.getBlockHash(height);
+
     return blockHash.toString();
   }
 


### PR DESCRIPTION
This PR changes the query used to get block hash by block number from `api.query.system.blockHash` to `api.rpc.chain.getBlockHash`. since the first one seem to work only for the last `250` blocks even in the `archive` mode, while the latter works for all block numbers.