### PR TITLE
Minor UX/UI improvements

### DIFF
--- a/packages/joy-proposals/src/Proposal/Body.tsx
+++ b/packages/joy-proposals/src/Proposal/Body.tsx
@@ -1,5 +1,5 @@
 import React from "react";
-import { Card, Header, Item, Button, Icon, Message } from "semantic-ui-react";
+import { Card, Header, Button, Icon, Message } from "semantic-ui-react";
 import { ProposalType } from "../runtime/transport";
 import { blake2AsHex } from '@polkadot/util-crypto';
 import styled from 'styled-components';
@@ -129,10 +129,10 @@ const ProposalParams = styled.div`
 `;
 const ProposalParamName = styled.div`
   margin-right: 1rem;
+  white-space: nowrap;
 `;
 const ProposalParamValue = styled.div`
   color: black;
-  padding-left: 1rem;
   word-wrap: break-word;
   word-break: break-all;
   @media screen and (max-width: 767px) {

--- a/packages/joy-proposals/src/Proposal/Body.tsx
+++ b/packages/joy-proposals/src/Proposal/Body.tsx
@@ -109,22 +109,24 @@ const paramParsers: { [x in ProposalType]: (params: any[]) => { [key: string]: s
   })
 };
 
-const ProposalParam = styled.div`
-  display: flex;
+const ProposalParams = styled.div`
+  display: grid;
   font-weight: bold;
-  margin-bottom: 0.5em;
-  @media only screen and (max-width: 767px) {
-    flex-direction: column;
+  grid-template-columns: min-content 1fr;
+  grid-row-gap: 0.5rem;
+  @media screen and (max-width: 767px) {
+    grid-template-columns: 1fr;
   }
 `;
 const ProposalParamName = styled.div`
-  min-width: ${(p: { longestParamName: number }) =>
-    p.longestParamName > 20 ? "240px" : p.longestParamName > 15 ? "200px" : ""};
+  margin-right: 1rem;
 `;
 const ProposalParamValue = styled.div`
   color: black;
   font-weight: bold;
-  padding-left: 0.5rem;
+  @media screen and (max-width: 767px) {
+    margin-top: -0.25rem;
+  }
 `;
 
 export default function Body({
@@ -140,7 +142,6 @@ export default function Body({
 }: BodyProps) {
   const parseParams = paramParsers[type];
   const parsedParams = parseParams(params);
-  const longestParamName: number = Object.keys(parsedParams).reduce((a, b) => (b.length > a ? b.length : a), 0);
   return (
     <Card fluid>
       <Card.Content>
@@ -149,16 +150,14 @@ export default function Body({
         </Card.Header>
         <Card.Description>{description}</Card.Description>
         <Header as="h4">Parameters:</Header>
-        <Item.Group style={{ textAlign: "left" }} relaxed>
-
-          { Object.entries(parseParams(params)).map(([paramName, paramValue]) => (
-
-            <ProposalParam key={paramName}>
-              <ProposalParamName longestParamName={longestParamName}>{paramName}:</ProposalParamName>
+        <ProposalParams>
+          { Object.entries(parsedParams).map(([paramName, paramValue]) => (
+            <React.Fragment key={paramName}>
+              <ProposalParamName>{paramName}:</ProposalParamName>
               <ProposalParamValue>{paramValue}</ProposalParamValue>
-            </ProposalParam>
+            </React.Fragment>
           ))}
-        </Item.Group>
+        </ProposalParams>
         { iAmProposer && isCancellable && (<>
           <Message warning active>
             <Message.Content>

--- a/packages/joy-proposals/src/Proposal/Proposal.css
+++ b/packages/joy-proposals/src/Proposal/Proposal.css
@@ -5,7 +5,12 @@
   }
 
   .details-container {
-    display: flex;
+    display: grid;
+    grid-template-columns: repeat(5, auto);
+  }
+
+  .details-container .item .extra {
+    margin-bottom: 0.5em !important;
   }
 
   h4.ui.header.details-handle {
@@ -36,5 +41,18 @@
 
   .ui.tabular.list-menu {
     margin-bottom: 2rem;
+  }
+
+  @media screen and (max-width: 767px) {
+    .details-container {
+      grid-template-columns: repeat(2, auto);
+      grid-template-rows: repeat(3, auto);
+    }
+    .details-container .item:first-child {
+      grid-column: 1/3;
+    }
+    .details-container .item {
+      margin: 0.5em 0 !important;
+    }
   }
 }

--- a/packages/joy-proposals/src/forms/GenericProposalForm.tsx
+++ b/packages/joy-proposals/src/forms/GenericProposalForm.tsx
@@ -11,11 +11,12 @@ import { MyAccountProps, withOnlyMembers } from "@polkadot/joy-utils/MyAccount";
 import { withMulti } from "@polkadot/react-api/with";
 import { withCalls } from "@polkadot/react-api";
 import { CallProps } from "@polkadot/react-api/types";
-import { Balance } from "@polkadot/types/interfaces";
+import { Balance, Event } from "@polkadot/types/interfaces";
 import { RouteComponentProps } from "react-router";
 import { ProposalType } from "../runtime";
 import { calculateStake } from "../utils";
 import "./forms.css";
+import { ProposalId } from "@joystream/types/proposals";
 
 
 // Generic form values
@@ -106,9 +107,18 @@ export const GenericProposalForm: React.FunctionComponent<GenericFormInnerProps>
   };
 
   const onTxSuccess: TxCallback = (txResult: SubmittableResult) => {
-    setSubmitting(false);
     if (!history) return;
-    history.push("/proposals");
+    // Determine proposal id
+    let createdProposalId: number | null = null;
+    for (let e of txResult.events) {
+      const event = e.get('event') as Event | undefined;
+      if (event !== undefined && event.method === 'ProposalCreated') {
+        createdProposalId = (event.data[1] as ProposalId).toNumber();
+        break;
+      }
+    }
+    setSubmitting(false);
+    history.push(`/proposals/${ createdProposalId }`);
   };
 
   const requiredStake: number | undefined =


### PR DESCRIPTION
This PR includes some minor UX/UI improvements based on https://github.com/Joystream/apps/issues/422

- Fixes `ProposalPreview` and `ProposalDetails` display on mobile (taking advantage of css-grid for `Create by`, `Proposal type`... section)
- Css grid for proposal details (which allows preservig both table-like symetry and correct wrapping on mobile)
- Adds redirect to proposal details instead of proposals list after proposal creation
- Takes advantage of `PromiseComponent` (which fixes loader) and adds a message if no proposals were found in `ProposalPreviewList`