### PR TITLE
Remove hardcoded "tJOY" references

### DIFF
--- a/packages/joy-proposals/src/Proposal/Body.tsx
+++ b/packages/joy-proposals/src/Proposal/Body.tsx
@@ -12,6 +12,7 @@ import { useTransport } from "../runtime";
 import { usePromise } from "../utils";
 import { Profile } from "@joystream/types/members";
 import { Option } from "@polkadot/types/";
+import { formatBalance } from "@polkadot/util";
 import PromiseComponent from "./PromiseComponent";
 
 type BodyProps = {
@@ -84,11 +85,11 @@ const paramParsers: { [x in ProposalType]: (params: any[]) => { [key: string]: s
       "Council size": params.council_size + " members",
       "Candidacy limit": params.candidacy_limit + " members",
       "New term duration": params.new_term_duration + " blocks",
-      "Min. council stake": params.min_council_stake + " tJOY",
-      "Min. voting stake": params.min_voting_stake + " tJOY"
+      "Min. council stake": formatBalance(params.min_council_stake),
+      "Min. voting stake": formatBalance(params.min_voting_stake)
   }),
   Spending: ([amount, account]) => ({
-    Amount: amount + " tJOY",
+    Amount: formatBalance(amount),
     Account: <ProposedAddress address={account} />
   }),
   SetLead: ([memberId, accountId]) => ({
@@ -96,7 +97,7 @@ const paramParsers: { [x in ProposalType]: (params: any[]) => { [key: string]: s
     "Account id": <ProposedAddress address={accountId} />
   }),
   SetContentWorkingGroupMintCapacity: ([capacity]) => ({
-    "Mint capacity": capacity + " tJOY"
+    "Mint capacity": formatBalance(capacity)
   }),
   EvictStorageProvider: ([accountId]) => ({
     "Storage provider account": <ProposedAddress address={accountId} />
@@ -105,16 +106,16 @@ const paramParsers: { [x in ProposalType]: (params: any[]) => { [key: string]: s
     "Validator count": count
   }),
   SetStorageRoleParameters: ([params]) => ({
-    "Min. stake": params.min_stake + " tJOY",
+    "Min. stake": formatBalance(params.min_stake),
     // "Min. actors": params.min_actors,
     "Max. actors": params.max_actors,
-    Reward: params.reward + " tJOY",
+    Reward: formatBalance(params.reward),
     "Reward period": params.reward_period + " blocks",
     // "Bonding period": params.bonding_period + " blocks",
     "Unbonding period": params.unbonding_period + " blocks",
     // "Min. service period": params.min_service_period + " blocks",
     // "Startup grace period": params.startup_grace_period + " blocks",
-    "Entry request fee": params.entry_request_fee + " tJOY"
+    "Entry request fee": formatBalance(params.entry_request_fee)
   })
 };
 
@@ -179,7 +180,7 @@ export default function Body({
               </p>
               <p style={{ margin: '0.5em 0', padding: '0' }}>
                 The cancellation fee for this type of proposal is:&nbsp;
-                <b>{ cancellationFee ? `${ cancellationFee } tJOY` : 'NONE' }</b>
+                <b>{ cancellationFee ? formatBalance(cancellationFee) : 'NONE' }</b>
               </p>
               <Button.Group color="red">
                 <TxButton

--- a/packages/joy-proposals/src/Proposal/ProposalTypePreview.tsx
+++ b/packages/joy-proposals/src/Proposal/ProposalTypePreview.tsx
@@ -6,6 +6,7 @@ import { Item, Icon, Button } from "semantic-ui-react";
 import { Category } from "./ChooseProposalType";
 import { ProposalType } from "../runtime";
 import { slugify, splitOnUpperCase } from "../utils";
+import { formatBalance } from "@polkadot/util";
 
 import "./ProposalType.css";
 
@@ -54,10 +55,10 @@ export default function ProposalTypePreview(props: ProposalTypePreviewProps) {
         <div className="proposal-details">
           <ProposalTypeDetail
             title="Stake"
-            value={ stake + "tJOY" } />
+            value={ formatBalance(stake) } />
           <ProposalTypeDetail
             title="Cancellation fee"
-            value={ cancellationFee ? `${cancellationFee} tJOY` : "NONE" } />
+            value={ cancellationFee ? formatBalance(cancellationFee) : "NONE" } />
           <ProposalTypeDetail
             title="Grace period"
             value={ gracePeriod ? `${gracePeriod} block${gracePeriod > 1 ? "s" : ""}` : "NONE" } />

--- a/packages/joy-proposals/src/forms/GenericProposalForm.tsx
+++ b/packages/joy-proposals/src/forms/GenericProposalForm.tsx
@@ -15,6 +15,7 @@ import { Balance } from "@polkadot/types/interfaces";
 import { RouteComponentProps } from "react-router";
 import { ProposalType } from "../runtime";
 import { calculateStake } from "../utils";
+import { formatBalance } from "@polkadot/util"
 import "./forms.css";
 
 
@@ -141,7 +142,7 @@ export const GenericProposalForm: React.FunctionComponent<GenericFormInnerProps>
         <Message warning visible>
           <Message.Content>
             <Icon name="warning circle" />
-            Required stake: <b>{requiredStake} tJOY</b>
+            Required stake: <b>{ formatBalance(requiredStake) }</b>
           </Message.Content>
         </Message>
         <div className="form-buttons">

--- a/packages/joy-proposals/src/forms/MintCapacityForm.tsx
+++ b/packages/joy-proposals/src/forms/MintCapacityForm.tsx
@@ -15,6 +15,7 @@ import Validation from "../validationSchema";
 import { InputFormField } from "./FormFields";
 import { withFormContainer } from "./FormContainer";
 import { ProposalType } from "../runtime";
+import { formatBalance } from "@polkadot/util";
 import "./forms.css";
 
 type FormValues = GenericFormValues & {
@@ -55,7 +56,7 @@ const MintCapacityForm: React.FunctionComponent<FormInnerProps> = props => {
         placeholder={ (initialData && initialData.capacity) }
         label={`${mintCapacityGroup} Mint Capacity`}
         help={`The new mint capacity you propse for ${mintCapacityGroup}`}
-        unit="tJOY"
+        unit={ formatBalance.getDefaults().unit }
         value={values.capacity}
       />
     </GenericProposalForm>

--- a/packages/joy-proposals/src/forms/SetStorageRoleParamsForm.tsx
+++ b/packages/joy-proposals/src/forms/SetStorageRoleParamsForm.tsx
@@ -20,6 +20,7 @@ import { u32 } from "@polkadot/types/primitive";
 import { createType } from "@polkadot/types";
 import { useTransport, StorageRoleParameters, IStorageRoleParameters } from "../runtime";
 import { usePromise } from "../utils";
+import { formatBalance } from "@polkadot/util";
 import "./forms.css";
 
 // Move to joy-types?
@@ -137,7 +138,7 @@ const SetStorageRoleParamsForm: React.FunctionComponent<FormInnerProps> = props 
           placeholder={placeholders.reward}
           error={errorLabelsProps.reward}
           value={values.reward}
-          unit="tJOY"
+          unit={ formatBalance.getDefaults().unit }
         />
         <InputFormField
           label="Reward period"
@@ -161,7 +162,7 @@ const SetStorageRoleParamsForm: React.FunctionComponent<FormInnerProps> = props 
           placeholder={placeholders.min_stake}
           error={errorLabelsProps.min_stake}
           value={values.min_stake}
-          unit="tJOY"
+          unit={ formatBalance.getDefaults().unit }
         />
         <InputFormField
           label="Min. service period"
@@ -223,7 +224,7 @@ const SetStorageRoleParamsForm: React.FunctionComponent<FormInnerProps> = props 
           placeholder={placeholders.entry_request_fee}
           error={errorLabelsProps.entry_request_fee}
           value={values.entry_request_fee}
-          unit="tJOY"
+          unit={ formatBalance.getDefaults().unit }
         />
       </Form.Group>
     </GenericProposalForm>

--- a/packages/joy-proposals/src/forms/SpendingProposalForm.tsx
+++ b/packages/joy-proposals/src/forms/SpendingProposalForm.tsx
@@ -16,6 +16,7 @@ import Validation from "../validationSchema";
 import { InputFormField, FormField } from "./FormFields";
 import { withFormContainer } from "./FormContainer";
 import { InputAddress } from "@polkadot/react-components/index";
+import { formatBalance } from "@polkadot/util";
 import "./forms.css";
 
 type FormValues = GenericFormValues & {
@@ -55,11 +56,10 @@ const SpendingProposalForm: React.FunctionComponent<FormInnerProps> = props => {
         label="Amount of tokens"
         help="The amount of tokens you propose to spend"
         onChange={handleChange}
-        className="tokens"
         name="tokens"
         placeholder="100"
         error={errorLabelsProps.tokens}
-        unit={"tJOY"}
+        unit={ formatBalance.getDefaults().unit }
         value={values.tokens}
       />
       <FormField

--- a/packages/joy-proposals/src/forms/forms.css
+++ b/packages/joy-proposals/src/forms/forms.css
@@ -11,12 +11,6 @@
     & input[name="tokens"] {
       max-width: 16rem;
     }
-
-    & .ui.input.tokens::after {
-      content: "tJOY";
-      position: absolute;
-      left: 5px;
-    }
   }
 
   .form-buttons {

--- a/packages/joy-proposals/src/validationSchema.ts
+++ b/packages/joy-proposals/src/validationSchema.ts
@@ -1,6 +1,13 @@
 import * as Yup from "yup";
 import { checkAddress } from "@polkadot/util-crypto";
 
+// TODO: If we really need this (currency unit) we can we make "Validation" a functiction that returns an object.
+// We could then "instantialize" it in "withFormContainer" where instead of passing
+// "validationSchema" (in each form component file) we would just pass "validationSchemaKey" or just "proposalType" (ie. SetLead).
+// Then we could let the "withFormContainer" handle the actual "validationSchema" for "withFormik". In that case it could easily
+// pass stuff like totalIssuance or currencyUnit here (ie.: const validationSchema = Validation(currencyUnit, totalIssuance)[proposalType];)
+const CURRENCY_UNIT = undefined;
+
 // All
 const TITLE_MAX_LENGTH = 40;
 const RATIONALE_MAX_LENGTH = 3000;
@@ -61,11 +68,11 @@ const MIN_SERVICE_PERIOD_MIN = 600;
 const MIN_SERVICE_PERIOD_MAX = 28800;
 const STARTUP_GRACE_PERIOD_MIN = 600;
 const STARTUP_GRACE_PERIOD_MAX = 28800;
-// const ENTRY_REQUEST_FEE_MIN = 0;
+const ENTRY_REQUEST_FEE_MIN = 1;
 const ENTRY_REQUEST_FEE_MAX = 100000;
 
 function errorMessage(name: string, min?: number | string, max?: number | string, unit?: string): string {
-  return `${name} should be at least ${min} and no more than ${max} ${unit ? `${unit}.` : "."}`;
+  return `${name} should be at least ${min} and no more than ${max}${unit ? ` ${unit}.` : "."}`;
 }
 
 /*
@@ -177,11 +184,11 @@ const Validation: ValidationType = {
       .integer("This field must be an integer.")
       .min(
         MIN_VOTING_STAKE_MIN,
-        errorMessage("The minimum voting stake", MIN_VOTING_STAKE_MIN, MIN_VOTING_STAKE_MAX, "tJOY")
+        errorMessage("The minimum voting stake", MIN_VOTING_STAKE_MIN, MIN_VOTING_STAKE_MAX, CURRENCY_UNIT)
       )
       .max(
         MIN_VOTING_STAKE_MAX,
-        errorMessage("The minimum voting stake", MIN_VOTING_STAKE_MIN, MIN_VOTING_STAKE_MAX, "tJOY")
+        errorMessage("The minimum voting stake", MIN_VOTING_STAKE_MIN, MIN_VOTING_STAKE_MAX, CURRENCY_UNIT)
       ),
     revealingPeriod: Yup.number()
       .required("All fields must be filled!")
@@ -199,11 +206,11 @@ const Validation: ValidationType = {
       .integer("This field must be an integer.")
       .min(
         MIN_COUNCIL_STAKE_MIN,
-        errorMessage("The minimum council stake", MIN_COUNCIL_STAKE_MIN, MIN_COUNCIL_STAKE_MAX, "tJOY")
+        errorMessage("The minimum council stake", MIN_COUNCIL_STAKE_MIN, MIN_COUNCIL_STAKE_MAX, CURRENCY_UNIT)
       )
       .max(
         MIN_COUNCIL_STAKE_MAX,
-        errorMessage("The minimum council stake", MIN_COUNCIL_STAKE_MIN, MIN_COUNCIL_STAKE_MAX, "tJOY")
+        errorMessage("The minimum council stake", MIN_COUNCIL_STAKE_MIN, MIN_COUNCIL_STAKE_MAX, CURRENCY_UNIT)
       ),
     newTermDuration: Yup.number()
       .required("All fields must be filled!")
@@ -244,8 +251,8 @@ const Validation: ValidationType = {
     mintCapacity: Yup.number()
       .positive("Mint capacity should be positive.")
       .integer("This field must be an integer.")
-      .min(MINT_CAPACITY_MIN, errorMessage("Mint capacity", MINT_CAPACITY_MIN, MINT_CAPACITY_MAX, "tJOY"))
-      .max(MINT_CAPACITY_MAX, errorMessage("Mint capacity", MINT_CAPACITY_MIN, MINT_CAPACITY_MAX, "tJOY"))
+      .min(MINT_CAPACITY_MIN, errorMessage("Mint capacity", MINT_CAPACITY_MIN, MINT_CAPACITY_MAX, CURRENCY_UNIT))
+      .max(MINT_CAPACITY_MAX, errorMessage("Mint capacity", MINT_CAPACITY_MIN, MINT_CAPACITY_MAX, CURRENCY_UNIT))
       .required("You need to specify a mint capacity.")
   },
   EvictStorageProvider: {
@@ -271,7 +278,7 @@ const Validation: ValidationType = {
       .required("All parameters are required")
       .positive("The minimum stake should be positive.")
       .integer("This field must be an integer.")
-      .max(MIN_STAKE_MAX, errorMessage("Minimum stake", MIN_STAKE_MIN, MIN_STAKE_MAX, "tJOY")),
+      .max(MIN_STAKE_MAX, errorMessage("Minimum stake", MIN_STAKE_MIN, MIN_STAKE_MAX, CURRENCY_UNIT)),
     min_actors: Yup.number()
       .required("All parameters are required")
       .integer("This field must be an integer.")
@@ -285,8 +292,8 @@ const Validation: ValidationType = {
     reward: Yup.number()
       .required("All parameters are required")
       .integer("This field must be an integer.")
-      .min(REWARD_MIN, errorMessage("Reward", REWARD_MIN, REWARD_MAX, "tJOY"))
-      .max(REWARD_MAX, errorMessage("Reward", REWARD_MIN, REWARD_MAX, "tJOY")),
+      .min(REWARD_MIN, errorMessage("Reward", REWARD_MIN, REWARD_MAX, CURRENCY_UNIT))
+      .max(REWARD_MAX, errorMessage("Reward", REWARD_MIN, REWARD_MAX, CURRENCY_UNIT)),
     reward_period: Yup.number()
       .required("All parameters are required")
       .integer("This field must be an integer.")
@@ -332,9 +339,15 @@ const Validation: ValidationType = {
       ),
     entry_request_fee: Yup.number()
       .required("All parameters are required")
-      .positive("The entry request fee should be positive.")
       .integer("This field must be an integer.")
-      .max(ENTRY_REQUEST_FEE_MAX, `The entry request fee should be less than ${ENTRY_REQUEST_FEE_MAX} tJOY.`)
+      .min(
+        ENTRY_REQUEST_FEE_MIN,
+        errorMessage("The entry request fee", ENTRY_REQUEST_FEE_MIN, ENTRY_REQUEST_FEE_MAX, CURRENCY_UNIT)
+      )
+      .max(
+        STARTUP_GRACE_PERIOD_MAX,
+        errorMessage("The entry request fee", ENTRY_REQUEST_FEE_MIN, ENTRY_REQUEST_FEE_MAX, CURRENCY_UNIT)
+      ),
   }
 };
 


### PR DESCRIPTION
This PR is related to: https://github.com/Joystream/apps/issues/430
It removes hardcoded `tJOY` references in `proposals` package and takes advantage of `formatBalance` instead (the way it's already handled in other packages).
Thanks to this it should (again) be very easy to change the "global unit" of currency in Pioneer by just changing the constant exposed by runtime.
I removed the references to currency completely from `validationSchema.ts` as they don't seem too necessary and "injecting" the unit there will require a little more work (I added a comment with proposed solution though, if at some point we'll need to pass some api props there)