### PR TITLE
Tab hell fix

### DIFF
--- a/packages/apps-routing/src/index.ts
+++ b/packages/apps-routing/src/index.ts
@@ -4,19 +4,19 @@
 
 import { Routing, Routes } from './types';
 
-import appSettings from '@polkadot/joy-settings/';
+// import appSettings from '@polkadot/joy-settings/';
 
 import election from './joy-election';
 import forum from './joy-forum';
-import help from './joy-help';
+// import help from './joy-help';
 import media from './joy-media';
 import members from './joy-members';
 import proposals from './joy-proposals';
 import roles from './joy-roles';
 import storageRoles from './joy-storage';
-import pages from './joy-pages';
+// import pages from './joy-pages';
 
-import template from './123code';
+// import template from './123code';
 import accounts from './accounts';
 import addressbook from './addressbook';
 // import claims from './claims';
@@ -24,74 +24,35 @@ import addressbook from './addressbook';
 // import council from './council';
 // import dashboard from './dashboard';
 // import democracy from './democracy';
-import explorer from './explorer';
-import extrinsics from './extrinsics';
+// import explorer from './explorer';
+// import extrinsics from './extrinsics';
 // import genericAsset from './generic-asset';
-import js from './js';
+// import js from './js';
 // import parachains from './parachains';
-import settings from './settings';
+// import settings from './settings';
 import staking from './staking';
-import storage from './storage';
-import sudo from './sudo';
-import toolbox from './toolbox';
-import transfer from './transfer';
+// import storage from './storage';
+// import sudo from './sudo';
+// import toolbox from './toolbox';
+// import transfer from './transfer';
 // import treasury from './treasury';
 
-const routes: Routes = appSettings.isBasicMode
-  ? ([] as Routes).concat(
-    explorer,
-    staking,
-    roles,
-    storageRoles,
-    transfer,
-    null,
-    media,
-    forum,
-    members,
-    accounts,
-    addressbook,
-    null,
-    election,
-    proposals,
-    null,
-    help,
-    settings,
-    template,
-    null,
-    pages
-  )
-  : ([] as Routes).concat(
-    // dashboard,
-    explorer,
-    staking,
-    roles,
-    storageRoles,
-    transfer,
-    null,
-    media,
-    forum,
-    members,
-    accounts,
-    addressbook,
-    null,
-    election,
-    proposals,
-    null,
-    storage,
-    extrinsics,
-    sudo,
-    null,
-    help,
-    settings,
-    toolbox,
-    js,
-    template,
-    null,
-    pages
-  );
-
+const routes: Routes = ([] as Routes).concat(
+  staking,
+  roles,
+  storageRoles,
+  null,
+  media,
+  forum,
+  members,
+  accounts,
+  addressbook,
+  null,
+  election,
+  proposals
+);
 const setup: Routing = {
-  default: 'explorer',
+  default: 'staking',
   routes
 };
 

--- a/packages/apps/src/SideBar/index.tsx
+++ b/packages/apps/src/SideBar/index.tsx
@@ -11,15 +11,14 @@ import React, { useState } from 'react';
 import styled from 'styled-components';
 import { Responsive } from 'semantic-ui-react';
 import routing from '@polkadot/apps-routing';
-import { Button, ChainImg, Icon, Menu, media } from '@polkadot/react-components';
+import { Button, ChainImg, Menu, media } from '@polkadot/react-components';
 import { classes } from '@polkadot/react-components/util';
 
 import translate from '../translate';
 import Item from './Item';
-import NodeInfo from './NodeInfo';
 import NetworkModal from '../modals/Network';
 
-import { SemanticICONS } from 'semantic-ui-react';
+// import { SemanticICONS } from 'semantic-ui-react';
 
 interface Props extends I18nProps /*ApiProps,*/ {
   className?: string;
@@ -30,22 +29,22 @@ interface Props extends I18nProps /*ApiProps,*/ {
   toggleMenu: () => void;
 }
 
-type OuterLinkProps = {
-  url: string,
-  title: string,
-  icon?: SemanticICONS
-};
+// type OuterLinkProps = {
+//   url: string;
+//   title: string;
+//   icon?: SemanticICONS;
+// };
 
-function OuterLink ({ url, title, icon = 'external alternate' }: OuterLinkProps) {
-  return (
-    <Menu.Item className='apps--SideBar-Item'>
-      <a className='apps--SideBar-Item-NavLink' href={url} target='_blank'>
-        <Icon name={icon} />
-        <span className='text'>{title}</span>
-      </a>
-    </Menu.Item>
-  );
-}
+// function OuterLink({ url, title, icon = 'external alternate' }: OuterLinkProps) {
+//   return (
+//     <Menu.Item className="apps--SideBar-Item">
+//       <a className="apps--SideBar-Item-NavLink" href={url} target="_blank">
+//         <Icon name={icon} />
+//         <span className="text">{title}</span>
+//       </a>
+//     </Menu.Item>
+//   );
+// }
 
 /*
 interface State {
@@ -109,99 +108,73 @@ class SideBar extends React.PureComponent<Props, State> {
           </Menu>
           <Responsive minWidth={SIDEBAR_MENU_THRESHOLD}>
 */
-function SideBar ({ className, collapse, handleResize, isCollapsed, toggleMenu, menuOpen }: Props): React.ReactElement<Props> {
+function SideBar({
+  className,
+  collapse,
+  handleResize,
+  isCollapsed,
+  toggleMenu,
+  menuOpen
+}: Props): React.ReactElement<Props> {
   const [modals, setModals] = useState<Record<string, boolean>>(
-    routing.routes.reduce((result: Record<string, boolean>, route): Record<string, boolean> => {
-      if (route && route.Modal) {
-        result[route.name] = false;
-      }
+    routing.routes.reduce(
+      (result: Record<string, boolean>, route): Record<string, boolean> => {
+        if (route && route.Modal) {
+          result[route.name] = false;
+        }
 
-      return result;
-    }, { network: false })
+        return result;
+      },
+      { network: false }
+    )
   );
 
-  const _toggleModal = (name: string): () => void =>
-    (): void => setModals({ ...modals, [name]: !modals[name] });
+  const _toggleModal = (name: string): (() => void) => (): void => setModals({ ...modals, [name]: !modals[name] });
 
   return (
     <Responsive
       onUpdate={handleResize}
       className={classes(className, 'apps-SideBar-Wrapper', isCollapsed ? 'collapsed' : 'expanded')}
     >
-      <ChainImg
-        className={`toggleImg ${menuOpen ? 'closed' : 'open delayed'}`}
-        onClick={toggleMenu}
-      />
-      {routing.routes.map((route): React.ReactNode => (
-        route && route.Modal
-          ? route.Modal && modals[route.name]
-            ? (
-              <route.Modal
-                key={route.name}
-                onClose={_toggleModal(route.name)}
-              />
+      <ChainImg className={`toggleImg ${menuOpen ? 'closed' : 'open delayed'}`} onClick={toggleMenu} />
+      {routing.routes.map(
+        (route): React.ReactNode =>
+          route && route.Modal ? (
+            route.Modal && modals[route.name] ? (
+              <route.Modal key={route.name} onClose={_toggleModal(route.name)} />
+            ) : (
+              <div key={route.name} />
             )
-            : <div key={route.name} />
-          : null
-      ))}
-      {modals.network && (
-        <NetworkModal onClose={_toggleModal('network')}/>
+          ) : null
       )}
-      <div className='apps--SideBar'>
-        <Menu
-          secondary
-          vertical
-        >
-          <div className='apps-SideBar-Scroll'>
+      {modals.network && <NetworkModal onClose={_toggleModal('network')} />}
+      <div className="apps--SideBar">
+        <Menu secondary vertical>
+          <div className="apps-SideBar-Scroll">
             {JoystreamLogo(isCollapsed)}
-            {routing.routes.map((route, index): React.ReactNode => (
-              route
-                ? (
+            {routing.routes.map(
+              (route, index): React.ReactNode =>
+                route ? (
                   <Item
                     isCollapsed={isCollapsed}
                     key={route.name}
                     route={route}
-                    onClick={
-                      route.Modal
-                        ? _toggleModal(route.name)
-                        : handleResize
-                    }
+                    onClick={route.Modal ? _toggleModal(route.name) : handleResize}
                   />
+                ) : (
+                  <Menu.Divider hidden key={index} />
                 )
-                : (
-                  <Menu.Divider
-                    hidden
-                    key={index}
-                  />
-                )
-            ))}
-            <Menu.Divider hidden />
-            <OuterLink url='https://faucet.joystream.org/' title='Free Tokens' />
-            <OuterLink url='https://blog.joystream.org/acropolis-incentives/' title='Earn Monero' />
-            <Menu.Divider hidden />
-            {
-              isCollapsed
-                ? undefined
-                : <NodeInfo />
-            }
+            )}
           </div>
           <Responsive
             minWidth={SIDEBAR_MENU_THRESHOLD}
             className={`apps--SideBar-collapse ${isCollapsed ? 'collapsed' : 'expanded'}`}
           >
-            <Button
-              icon={`angle double ${isCollapsed ? 'right' : 'left'}`}
-              isBasic
-              isCircular
-              onClick={collapse}
-            />
+            <Button icon={`angle double ${isCollapsed ? 'right' : 'left'}`} isBasic isCircular onClick={collapse} />
           </Responsive>
         </Menu>
         <Responsive minWidth={SIDEBAR_MENU_THRESHOLD}>
-          <div
-            className='apps--SideBar-toggle'
-            onClick={collapse}
-          />
+          <div className="apps--SideBar-toggle" onClick={collapse} />
         </Responsive>
       </div>
     </Responsive>
@@ -237,16 +210,7 @@ export default translate(
   `
 );
 
-
-function JoystreamLogo (isCollapsed: boolean) {
-  const logo = isCollapsed
-  ? 'images/logo-j.svg'
-  : 'images/logo-joytream.svg';
-  return (
-  <img
-    alt='Joystream'
-    className='apps--SideBar-logo'
-    src={logo}
-  />
-  );
+function JoystreamLogo(isCollapsed: boolean) {
+  const logo = isCollapsed ? 'images/logo-j.svg' : 'images/logo-joytream.svg';
+  return <img alt="Joystream" className="apps--SideBar-logo" src={logo} />;
 }

--- a/packages/apps/src/index.tsx
+++ b/packages/apps/src/index.tsx
@@ -27,6 +27,16 @@ import Apps from './Apps';
 const rootId = 'root';
 const rootElement = document.getElementById(rootId);
 
+(window as any).Joystream = {
+  setRemoteEndpoint: (apiUrl: string) => {
+    settings.set({
+      apiUrl
+    });
+
+    window.location.reload();
+  }
+};
+
 // we split here so that both these forms are allowed
 //  - http://localhost:3000/?rpc=wss://substrate-rpc.parity.io/#/explorer
 //  - http://localhost:3000/#/explorer?rpc=wss://substrate-rpc.parity.io
@@ -66,16 +76,12 @@ if (!rootElement) {
 }
 
 ReactDOM.render(
-  <Suspense fallback='...'>
+  <Suspense fallback="...">
     <MyAccountProvider>
       <Queue>
         <QueueConsumer>
           {({ queuePayload, queueSetTxStatus }): React.ReactNode => (
-            <Api
-              queuePayload={queuePayload}
-              queueSetTxStatus={queueSetTxStatus}
-              url={wsEndpoint}
-            >
+            <Api queuePayload={queuePayload} queueSetTxStatus={queueSetTxStatus} url={wsEndpoint}>
               <MyMembershipProvider>
                 <BlockAuthors>
                   <Events>


### PR DESCRIPTION
## Tab hell fix
Implements #439

You now have to use the console to manually set a custom RPC endpoint because we removed the `Settings` tab.

You can do so by using `setRemoteEndpoint` method on the `Joystream` global object.

You can for example write the following into the console:

 `Joystream.setRemoteEndpoint("wss://constantinople-reckless.joystream.org/staging/rpc")`

## Preview
![Tab hell fix](https://i.gyazo.com/8e410519189ecec7516ca85ddd899d7b.png)
