### PR TITLE
revert forum type ThreadId to u64

### DIFF
--- a/packages/joy-types/src/forum.ts
+++ b/packages/joy-types/src/forum.ts
@@ -90,7 +90,7 @@ export class CategoryId extends u64 {}
 export class OptionCategoryId extends Option.with(CategoryId) {}
 export class VecCategoryId extends Vector.with(CategoryId) {}
 
-export class ThreadId extends u32 {}
+export class ThreadId extends u64 {}
 export class VecThreadId extends Vector.with(ThreadId) {}
 
 export class PostId extends u64 {}


### PR DESCRIPTION
Fixes https://github.com/Joystream/apps/issues/434

To avoid breaking the Proposals Discussion in future, there is a related runtime PR: https://github.com/Joystream/joystream/pull/422