### PR TITLE
Media entities conversion - ignore and log error for entities without schema

### DIFF
--- a/packages/joy-types/src/versioned-store/EntityCodec.ts
+++ b/packages/joy-types/src/versioned-store/EntityCodec.ts
@@ -200,8 +200,8 @@ export abstract class EntityCodec<T extends PlainEntity> {
       id: entity.id.toNumber()
     }
 
-    if (!entity.in_class_schema_indexes.toArray().length && !entity.entity_values.toArray().length) {
-      throw new Error(`Trying to convert empty entity to plain object! (Entity id: ${res.id})`);
+    if (!entity.in_class_schema_indexes.toArray().length) {
+      throw new Error(`No schema support exists for entity! Entity id: ${res.id}`);
     }
 
     for (const v of entity.entity_values) {

--- a/packages/joy-types/src/versioned-store/EntityCodec.ts
+++ b/packages/joy-types/src/versioned-store/EntityCodec.ts
@@ -200,7 +200,7 @@ export abstract class EntityCodec<T extends PlainEntity> {
       id: entity.id.toNumber()
     }
 
-    if (!entity.entity_values.toArray().length) {
+    if (!entity.in_class_schema_indexes.toArray().length && !entity.entity_values.toArray().length) {
       throw new Error(`Trying to convert empty entity to plain object! (Entity id: ${res.id})`);
     }
 

--- a/packages/joy-types/src/versioned-store/EntityCodec.ts
+++ b/packages/joy-types/src/versioned-store/EntityCodec.ts
@@ -200,6 +200,10 @@ export abstract class EntityCodec<T extends PlainEntity> {
       id: entity.id.toNumber()
     }
 
+    if (!entity.entity_values.toArray().length) {
+      throw new Error(`Trying to convert empty entity to plain object! (Entity id: ${res.id})`);
+    }
+
     for (const v of entity.entity_values) {
       const propIdx = v.in_class_index.toNumber();
       const propName = this.propIndexToNameMap.get(propIdx);


### PR DESCRIPTION
Attempt to fix an error that occured on https://testnet.joystream.org/ due to some `Video` entities beeing created but with no schema added.

During the process of publishing the video, there are 4 batched operations beeing performed with one extrinsic:
1. `createEntity` of class 1
2. `addSchemaSupportToEntity` of class 1
3. `createEntity` of class 7
4. `addSchemaSupportToEntity` of class 7

If the last one fails/is omitted, it results in an entity with emtpy `in_class_schema_indexes` and empty `entity_values`, which is currently unexpected by Pioneer and crashes the entire media page.

Fixed by ignoring those entities during the processing, but logging an approperiate error in the console in such case.